### PR TITLE
test(unit): add 14 unhappy-path tests and fix two controller bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,33 @@ Apache 2.0 — CAM Labs LLC
 
 This project is being developed with the goal of presenting at KubeCon NA 2026 (November 9–12, Salt Lake City). See `KUBECON.md` for the full talk framing.
 
-**Ask of Claude Code:** As you build, please help capture the story. When you hit something non-obvious — a surprising constraint, a design tradeoff, an elegant solution, or something that broke in an unexpected way — add a short entry to the **"Interesting Problems Encountered"** section in `KUBECON.md`. One paragraph is enough. These notes become the raw material for the talk narrative and are the difference between a good proposal and a great one.
+### Release Timeline
+
+All milestones and issues are tracked on GitHub. The CFP opens May/June 2026 — v0.2.0 must close before then so there is a working demo to write the proposal around.
+
+| Version | GitHub Milestone | Due | What it unlocks |
+|---------|-----------------|-----|-----------------|
+| **v0.1.0** | Initial Release | Apr 30 2026 | Core operator, 50+25+19 tests, CI — PRs #2 + #3 |
+| **v0.2.0** | Foundation & Real Runner | Jun 1 2026 | Real `claude-code-runner` image, E2E test, mailbox PVC validation, talk-ready `describe` output |
+| **v0.3.0** | Observability & Budget | Jul 15 2026 | Prometheus metrics, `internal/budget` package, webhook engine, Grafana dashboard |
+| **v0.4.0** | Resilience & RBAC | Aug 31 2026 | Crash re-spawn, per-agent ServiceAccounts, `onComplete: create-pr`, `onComplete: push-branch` |
+| **v0.5.0** | Template Engine & Helm | Sep 30 2026 | `AgentTeamTemplate`/`AgentTeamRun` controllers, production Helm chart, CONTRIBUTING.md |
+| **v1.0.0** | KubeCon Demo Polish | Oct 20 2026 | Demo script, real-API CI test, CFP submitted, OCI skill distribution |
+
+**KubeCon talk:** November 9–12 2026, Salt Lake City. CFP deadline: May/June 2026 (watch https://sessionize.com/kubecon-cloudnativecon-north-america-2026/).
+
+### Current Priority (v0.2.0)
+
+The highest-value issues for the next milestone are:
+1. **#4** — Build and publish the `claude-code-runner` Docker image (prerequisite for everything)
+2. **#6** — Validate mailbox file exchange on shared PVC in Kind (core architectural claim)
+3. **#5** — Real E2E acceptance test against Claude API
+4. **#7** — Make `kubectl describe agentteam` talk-ready (`+kubebuilder:printcolumn`, Events)
+5. **#8** — Document the RWX PVC constraint in ARCHITECTURE.md
+
+### Ask of Claude Code
+
+As you build, help capture the story. When you hit something non-obvious — a surprising constraint, a design tradeoff, an elegant solution, or something that broke in an unexpected way — add a short entry to the **"Interesting Problems Encountered"** section in `KUBECON.md`. One paragraph is enough. These notes become the raw material for the talk narrative.
 
 Specifically worth logging:
 - Anything awkward about modeling long-running agent state in a K8s reconciler

--- a/TESTING.md
+++ b/TESTING.md
@@ -27,9 +27,9 @@ go test ./internal/controller/... -run TestReconcilePending_CodingMode
 go test ./internal/controller/... -coverprofile=cover.out && go tool cover -html=cover.out
 ```
 
-### What is covered (36 tests)
+### What is covered (50 tests)
 
-#### Reconciler phases
+#### Reconciler phases — happy path
 
 | Test | What it verifies |
 |------|-----------------|
@@ -45,8 +45,22 @@ go test ./internal/controller/... -coverprofile=cover.out && go tool cover -html
 | `TestReconcileRunning_Timeout_SetsTimedOut` | sets `TimedOut` when elapsed time exceeds `lifecycle.timeout` |
 | `TestReconcileRunning_BudgetExceeded_SetsBudgetExceeded` | sets `BudgetExceeded` when estimated cost exceeds `lifecycle.budgetLimit` |
 | `TestReconcileRunning_AllPodsSucceeded_SetsCompleted` | sets `Completed` when lead and all teammates are `Succeeded` |
-| `TestReconcileRunning_PodFailed_SetsFailedPhase` | sets `Failed` when any pod enters `Failed` phase |
+| `TestReconcileRunning_PodFailed_SetsFailedPhase` | sets `Failed` when lead pod enters `Failed` phase |
 | `TestReconcileRunning_SpawnsNewlyUnblockedTeammate` | spawns a teammate mid-run once its `dependsOn` dep completes |
+
+#### Reconciler phases — unhappy path
+
+| Test | What it verifies |
+|------|-----------------|
+| `TestReconcileInitializing_InitJobMissing_Waits` | requeues when init Job is absent (operator restart mid-reconcile) |
+| `TestReconcileInitializing_HangingInitJob_TimesOut` | sets `TimedOut` when init Job is still running past `lifecycle.timeout` |
+| `TestReconcileRunning_TeammateFailure_SetsFailedPhase` | sets `Failed` when a teammate pod fails while lead is still running |
+| `TestReconcileRunning_LeadNotSpawned_KeepsRunning` | requeues without completing when lead pod does not yet exist |
+| `TestReconcileRunning_Timeout_TerminatesPods` | deletes all running pods when team times out |
+| `TestReconcileRunning_BudgetExceeded_TerminatesPods` | deletes all running pods when budget is exceeded |
+| `TestReconcileTerminal_StampsCompletedAt` | stamps `completedAt` timestamp on first terminal reconcile |
+| `TestReconcileTerminal_Idempotent` | does not overwrite `completedAt` on subsequent terminal reconciles |
+| `TestReconcileTerminal_DeletesRunningPods` | deletes all team pods when entering terminal phase |
 
 #### Pod builder
 
@@ -58,6 +72,8 @@ go test ./internal/controller/... -coverprofile=cover.out && go tool cover -html
 | `TestBuildAgentPod_WithMCPServers` | `mcp-config` volume mounted at `/var/claude-mcp` |
 | `TestBuildAgentPod_CoworkMode` | workspace-output and workspace-input volumes present; no repo volume |
 | `TestBuildAgentPod_ScopeEnvVars` | `SCOPE_INCLUDE_PATHS` and `SCOPE_EXCLUDE_PATHS` set from `scope` spec |
+| `TestBuildAgentPod_OAuthAuth` | `CLAUDE_OAUTH_TOKEN` injected via SecretKeyRef when `oauthSecret` set; no API key env var |
+| `TestBuildAgentPod_AgentCommandOverride` | `AgentCommand` reconciler field overrides container command |
 
 #### Business logic
 
@@ -75,9 +91,12 @@ go test ./internal/controller/... -coverprofile=cover.out && go tool cover -html
 | `TestDependenciesMet_DepSucceeded` | returns true when dependency pod is `Succeeded` |
 | `TestDependenciesMet_DepNotSpawned` | returns false when dependency pod does not exist |
 | `TestDependenciesMet_DepStillRunning` | returns false when dependency pod is `Running` |
+| `TestDependenciesMet_DepFailed_NotMet` | returns false when dependency pod is `Failed` (only Succeeded counts) |
+| `TestDependenciesMet_AllMustSucceed` | returns false when any one of multiple deps is not yet Succeeded |
 | `TestCheckApprovalGate_NoGateDefined` | returns approved when no gate matches the event |
 | `TestCheckApprovalGate_GatePresentNotApproved` | returns not approved when gate exists but annotation absent |
 | `TestCheckApprovalGate_ApprovedViaAnnotation` | returns approved when annotation is set to `"true"` |
+| `TestSyncPodStatuses_ReflectsPodPhases` | `team.Status.Lead` and `team.Status.Teammates` reflect live pod phases |
 
 ### Test helpers
 

--- a/internal/budget/doc.go
+++ b/internal/budget/doc.go
@@ -11,8 +11,9 @@
 //   - IsOverBudget() → bool
 //
 // Cost rates (as of April 2026):
-//   Opus 4.6:   $5/M input,  $25/M output
-//   Sonnet 4.6: $3/M input,  $15/M output
+//
+//	Opus 4.6:   $5/M input,  $25/M output
+//	Sonnet 4.6: $3/M input,  $15/M output
 //
 // Estimation heuristic:
 //   - Assume ~50K input tokens per minute of active session (model loading context)

--- a/internal/controller/agentteam_controller.go
+++ b/internal/controller/agentteam_controller.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	defaultAgentImage = "ghcr.io/camlabs/claude-code-runner:latest"
+	defaultAgentImage = "ghcr.io/amcheste/claude-code-runner:latest"
 	defaultInitImage  = "alpine/git:latest"
 )
 
@@ -170,6 +170,15 @@ func (r *AgentTeamReconciler) reconcilePending(ctx context.Context, team *claude
 func (r *AgentTeamReconciler) reconcileInitializing(ctx context.Context, team *claudev1alpha1.AgentTeam) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
 	log.Info("Phase: Initializing")
+
+	// Enforce timeout even during initialization — prevents a team being permanently
+	// stuck on a slow or hung init Job.
+	if r.isTimedOut(team) {
+		log.Info("Team timed out during initialization")
+		team.Status.Phase = "TimedOut"
+		setCondition(team, "Progressing", metav1.ConditionFalse, "TimedOut", "Team exceeded configured timeout during initialization")
+		return ctrl.Result{}, r.Status().Update(ctx, team)
+	}
 
 	// In coding mode, wait for the init Job before spawning pods.
 	if team.Spec.Repository != nil && team.Spec.Repository.URL != "" {
@@ -449,7 +458,7 @@ echo "[init] Done"
 								}
 								return []string{"sh", "-c", initScript}
 							}(),
-							Env:     envVars,
+							Env: envVars,
 							VolumeMounts: []corev1.VolumeMount{
 								{Name: "repo", MountPath: "/workspace"},
 								{Name: "team-state", MountPath: "/state"},
@@ -815,7 +824,7 @@ func (r *AgentTeamReconciler) allPodsComplete(ctx context.Context, team *claudev
 		pod := &corev1.Pod{}
 		if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: team.Namespace}, pod); err != nil {
 			if errors.IsNotFound(err) {
-				return false, false, nil // Not yet spawned.
+				return false, false, nil // Not yet spawned — keep waiting.
 			}
 			return false, false, err
 		}
@@ -829,26 +838,34 @@ func (r *AgentTeamReconciler) allPodsComplete(ctx context.Context, team *claudev
 		}
 	}
 
-	// Lead must succeed.
+	// Scan every pod (lead + all teammates) in a single pass so that a failed
+	// teammate is detected even while the lead is still running.
+	allSucceeded := true
+
 	done, failed, err := checkPod(agentPodName(team, "lead"))
-	if err != nil || failed {
-		return false, failed, err
+	if err != nil {
+		return false, false, err
+	}
+	if failed {
+		return false, true, nil
 	}
 	if !done {
-		return false, false, nil
+		allSucceeded = false
 	}
 
-	// All spawned teammates must succeed.
 	for _, tm := range team.Spec.Teammates {
 		done, failed, err := checkPod(agentPodName(team, tm.Name))
-		if err != nil || failed {
-			return false, failed, err
+		if err != nil {
+			return false, false, err
+		}
+		if failed {
+			return false, true, nil
 		}
 		if !done {
-			return false, false, nil
+			allSucceeded = false
 		}
 	}
-	return true, false, nil
+	return allSucceeded, false, nil
 }
 
 func (r *AgentTeamReconciler) executeOnComplete(ctx context.Context, team *claudev1alpha1.AgentTeam) error {

--- a/internal/controller/agentteam_controller_test.go
+++ b/internal/controller/agentteam_controller_test.go
@@ -657,6 +657,268 @@ func TestCheckApprovalGate_ApprovedViaAnnotation(t *testing.T) {
 	assert.True(t, approved)
 }
 
+// --- reconcileTerminal ---
+
+func TestReconcileTerminal_StampsCompletedAt(t *testing.T) {
+	team := minimalTeam("term-stamp")
+	team.Status.Phase = "Completed"
+	r := newReconciler(team)
+	team = fetch(t, r, "term-stamp")
+	ctx := context.Background()
+
+	_, err := r.reconcileTerminal(ctx, team)
+	require.NoError(t, err)
+	assert.NotNil(t, team.Status.CompletedAt, "reconcileTerminal should stamp CompletedAt")
+}
+
+func TestReconcileTerminal_Idempotent(t *testing.T) {
+	team := minimalTeam("term-idem")
+	team.Status.Phase = "Completed"
+	r := newReconciler(team)
+	team = fetch(t, r, "term-idem")
+	ctx := context.Background()
+
+	_, err := r.reconcileTerminal(ctx, team)
+	require.NoError(t, err)
+	require.NotNil(t, team.Status.CompletedAt)
+	firstStamp := team.Status.CompletedAt.Time
+
+	// Second call must not error and must not re-stamp CompletedAt.
+	team = fetch(t, r, "term-idem")
+	require.NotNil(t, team.Status.CompletedAt, "CompletedAt must be persisted after first call")
+
+	_, err = r.reconcileTerminal(ctx, team)
+	require.NoError(t, err, "second reconcileTerminal call must not error")
+	assert.Equal(t, firstStamp.Unix(), team.Status.CompletedAt.Time.Unix(),
+		"second call must not overwrite CompletedAt")
+}
+
+func TestReconcileTerminal_DeletesRunningPods(t *testing.T) {
+	team := minimalTeam("term-delete")
+	team.Status.Phase = "Failed"
+	leadPod := runningPod("term-delete-lead", "default", "term-delete")
+	workerPod := runningPod("term-delete-worker", "default", "term-delete")
+	r := newReconciler(team, leadPod, workerPod)
+	team = fetch(t, r, "term-delete")
+	ctx := context.Background()
+
+	_, err := r.reconcileTerminal(ctx, team)
+	require.NoError(t, err)
+
+	var pod corev1.Pod
+	assert.True(t, errors.IsNotFound(r.Get(ctx, types.NamespacedName{Name: "term-delete-lead", Namespace: "default"}, &pod)),
+		"lead pod should be deleted in terminal phase")
+	assert.True(t, errors.IsNotFound(r.Get(ctx, types.NamespacedName{Name: "term-delete-worker", Namespace: "default"}, &pod)),
+		"worker pod should be deleted in terminal phase")
+}
+
+// --- reconcileRunning: cleanup on timeout/budget ---
+
+func TestReconcileRunning_Timeout_TerminatesPods(t *testing.T) {
+	team := withLifecycle(minimalTeam("timeout-cleanup"), "1m", "100.00")
+	leadPod := runningPod("timeout-cleanup-lead", "default", "timeout-cleanup")
+	workerPod := runningPod("timeout-cleanup-worker", "default", "timeout-cleanup")
+	startTime := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+
+	r := newReconciler(team, leadPod, workerPod)
+	team = fetch(t, r, "timeout-cleanup")
+	team.Status.Phase = "Running"
+	team.Status.StartedAt = &startTime
+	ctx := context.Background()
+
+	_, err := r.reconcileRunning(ctx, team)
+	require.NoError(t, err)
+	assert.Equal(t, "TimedOut", team.Status.Phase)
+
+	var pod corev1.Pod
+	assert.True(t, errors.IsNotFound(r.Get(ctx, types.NamespacedName{Name: "timeout-cleanup-lead", Namespace: "default"}, &pod)),
+		"lead pod must be deleted when team times out")
+	assert.True(t, errors.IsNotFound(r.Get(ctx, types.NamespacedName{Name: "timeout-cleanup-worker", Namespace: "default"}, &pod)),
+		"worker pod must be deleted when team times out")
+}
+
+func TestReconcileRunning_BudgetExceeded_TerminatesPods(t *testing.T) {
+	budget := "0.01" // tiny budget, exceeded after 60 minutes of running
+	team := minimalTeam("budget-cleanup")
+	team.Spec.Lifecycle = &claudev1alpha1.LifecycleSpec{BudgetLimit: &budget}
+	leadPod := runningPod("budget-cleanup-lead", "default", "budget-cleanup")
+	workerPod := runningPod("budget-cleanup-worker", "default", "budget-cleanup")
+	startTime := metav1.NewTime(time.Now().Add(-60 * time.Minute))
+
+	r := newReconciler(team, leadPod, workerPod)
+	team = fetch(t, r, "budget-cleanup")
+	team.Status.Phase = "Running"
+	team.Status.StartedAt = &startTime
+	ctx := context.Background()
+
+	_, err := r.reconcileRunning(ctx, team)
+	require.NoError(t, err)
+	assert.Equal(t, "BudgetExceeded", team.Status.Phase)
+
+	var pod corev1.Pod
+	assert.True(t, errors.IsNotFound(r.Get(ctx, types.NamespacedName{Name: "budget-cleanup-lead", Namespace: "default"}, &pod)),
+		"lead pod must be deleted when budget is exceeded")
+	assert.True(t, errors.IsNotFound(r.Get(ctx, types.NamespacedName{Name: "budget-cleanup-worker", Namespace: "default"}, &pod)),
+		"worker pod must be deleted when budget is exceeded")
+}
+
+// --- reconcileRunning: teammate failure ---
+
+func TestReconcileRunning_TeammateFailure_SetsFailedPhase(t *testing.T) {
+	// Lead is still running; a teammate pod fails. Team must move to Failed.
+	team := minimalTeam("teammate-fail")
+	leadPod := runningPod("teammate-fail-lead", "default", "teammate-fail")
+	workerPod := failedPod("teammate-fail-worker", "default", "teammate-fail")
+	startTime := metav1.NewTime(time.Now().Add(-1 * time.Minute))
+
+	r := newReconciler(team, leadPod, workerPod)
+	team = fetch(t, r, "teammate-fail")
+	team.Status.Phase = "Running"
+	team.Status.StartedAt = &startTime
+	ctx := context.Background()
+
+	_, err := r.reconcileRunning(ctx, team)
+	require.NoError(t, err)
+	assert.Equal(t, "Failed", team.Status.Phase)
+}
+
+// --- reconcileRunning: pods not yet spawned ---
+
+func TestReconcileRunning_LeadNotSpawned_KeepsRunning(t *testing.T) {
+	// Team entered Running but lead pod has not been created yet (e.g. race on first reconcile).
+	// Operator should requeue and wait rather than prematurely completing.
+	team := minimalTeam("no-lead")
+	startTime := metav1.NewTime(time.Now().Add(-1 * time.Minute))
+	r := newReconciler(team) // no pods in cluster
+	team = fetch(t, r, "no-lead")
+	team.Status.Phase = "Running"
+	team.Status.StartedAt = &startTime
+	ctx := context.Background()
+
+	result, err := r.reconcileRunning(ctx, team)
+	require.NoError(t, err)
+	assert.Equal(t, "Running", team.Status.Phase, "phase must not advance before lead pod is spawned")
+	assert.Equal(t, 30*time.Second, result.RequeueAfter)
+}
+
+// --- reconcileInitializing: edge cases ---
+
+func TestReconcileInitializing_InitJobMissing_Waits(t *testing.T) {
+	// Coding team where the init Job was never created (e.g. operator restarted mid-reconcile).
+	// Operator should requeue rather than proceeding to deploy pods.
+	team := withRepo(minimalTeam("no-job-team"))
+	r := newReconciler(team) // no Job object in cluster
+	team = fetch(t, r, "no-job-team")
+	ctx := context.Background()
+
+	result, err := r.reconcileInitializing(ctx, team)
+	require.NoError(t, err)
+	assert.Equal(t, 10*time.Second, result.RequeueAfter)
+	assert.Empty(t, team.Status.Phase, "phase must not advance while init job is absent/incomplete")
+}
+
+func TestReconcileInitializing_HangingInitJob_TimesOut(t *testing.T) {
+	// Init Job is still Active but the team's configured timeout has elapsed.
+	// Without a timeout check in reconcileInitializing the team would be stuck forever.
+	team := withLifecycle(withRepo(minimalTeam("hang-team")), "1m", "100.00")
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "hang-team-init", Namespace: "default"},
+		Status:     batchv1.JobStatus{Active: 1},
+	}
+	r := newReconciler(team, job)
+	team = fetch(t, r, "hang-team")
+	// Simulate the team having started 2 minutes ago (past the 1-minute timeout).
+	team.Status.StartedAt = &metav1.Time{Time: time.Now().Add(-2 * time.Minute)}
+	ctx := context.Background()
+
+	_, err := r.reconcileInitializing(ctx, team)
+	require.NoError(t, err)
+	assert.Equal(t, "TimedOut", team.Status.Phase,
+		"team must time out even when stuck waiting for a hung init job")
+}
+
+// --- dependenciesMet: additional edge cases ---
+
+func TestDependenciesMet_DepFailed_NotMet(t *testing.T) {
+	// A failed pod must NOT satisfy a dependency — only Succeeded counts.
+	team := minimalTeam("dep-fail")
+	pod := failedPod("dep-fail-first", "default", "dep-fail")
+	r := newReconciler(team, pod)
+	assert.False(t, r.dependenciesMet(context.Background(), team, []string{"first"}),
+		"a failed dependency pod must not be considered met")
+}
+
+func TestDependenciesMet_AllMustSucceed(t *testing.T) {
+	// All listed dependencies must have Succeeded; one still Running blocks the gate.
+	team := minimalTeam("dep-all")
+	first := succeededPod("dep-all-first", "default", "dep-all")
+	second := runningPod("dep-all-second", "default", "dep-all")
+	r := newReconciler(team, first, second)
+	assert.False(t, r.dependenciesMet(context.Background(), team, []string{"first", "second"}),
+		"all dependencies must have Succeeded — one Running is not enough")
+}
+
+// --- buildAgentPod: auth and command override ---
+
+func TestBuildAgentPod_OAuthAuth(t *testing.T) {
+	team := minimalTeam("oauth-test")
+	team.Spec.Auth.APIKeySecret = ""
+	team.Spec.Auth.OAuthSecret = "my-oauth-secret"
+	r := newReconciler(team)
+
+	pod := r.buildAgentPod(team, "worker", "sonnet", "work", "auto-accept", false,
+		corev1.ResourceRequirements{}, nil, nil, nil)
+
+	// ANTHROPIC_API_KEY must NOT be injected when OAuth is configured.
+	env := envMap(pod)
+	_, hasAPIKey := env["ANTHROPIC_API_KEY"]
+	assert.False(t, hasAPIKey, "ANTHROPIC_API_KEY must not be set when OAuth is used")
+
+	// CLAUDE_OAUTH_TOKEN must be set via SecretKeyRef (ValueFrom, not plain Value).
+	var foundOAuth bool
+	for _, e := range pod.Spec.Containers[0].Env {
+		if e.Name == "CLAUDE_OAUTH_TOKEN" {
+			foundOAuth = true
+			require.NotNil(t, e.ValueFrom, "CLAUDE_OAUTH_TOKEN must use ValueFrom SecretKeyRef")
+			assert.Equal(t, "my-oauth-secret", e.ValueFrom.SecretKeyRef.Name)
+		}
+	}
+	assert.True(t, foundOAuth, "CLAUDE_OAUTH_TOKEN env var must be present")
+}
+
+func TestBuildAgentPod_AgentCommandOverride(t *testing.T) {
+	team := minimalTeam("cmd-test")
+	r := newReconciler(team)
+	r.AgentCommand = []string{"sh", "-c", "exit 0"}
+
+	pod := r.buildAgentPod(team, "worker", "sonnet", "work", "auto-accept", false,
+		corev1.ResourceRequirements{}, nil, nil, nil)
+
+	assert.Equal(t, []string{"sh", "-c", "exit 0"}, pod.Spec.Containers[0].Command,
+		"AgentCommand override must be applied to the container spec")
+}
+
+// --- syncPodStatuses ---
+
+func TestSyncPodStatuses_ReflectsPodPhases(t *testing.T) {
+	team := minimalTeam("sync-test")
+	leadPod := succeededPod("sync-test-lead", "default", "sync-test")
+	workerPod := runningPod("sync-test-worker", "default", "sync-test")
+	r := newReconciler(team, leadPod, workerPod)
+	team = fetch(t, r, "sync-test")
+	ctx := context.Background()
+
+	require.NoError(t, r.syncPodStatuses(ctx, team))
+
+	require.NotNil(t, team.Status.Lead)
+	assert.Equal(t, "sync-test-lead", team.Status.Lead.PodName)
+	assert.Equal(t, "Completed", team.Status.Lead.Phase)
+
+	require.Len(t, team.Status.Teammates, 1)
+	assert.Equal(t, "sync-test-worker", team.Status.Teammates[0].PodName)
+	assert.Equal(t, "Running", team.Status.Teammates[0].Phase)
+}
+
 // --- Pod/Volume introspection helpers ---
 
 func envMap(pod *corev1.Pod) map[string]string {

--- a/internal/controller/agentteam_integration_test.go
+++ b/internal/controller/agentteam_integration_test.go
@@ -44,8 +44,8 @@ func codingTeam(name, namespace string) *claudev1alpha1.AgentTeam {
 				URL:    "https://github.com/example/repo",
 				Branch: "main",
 			},
-			Auth:  claudev1alpha1.AuthSpec{APIKeySecret: "api-key"},
-			Lead:  claudev1alpha1.LeadSpec{Model: "opus", Prompt: "Lead the team"},
+			Auth: claudev1alpha1.AuthSpec{APIKeySecret: "api-key"},
+			Lead: claudev1alpha1.LeadSpec{Model: "opus", Prompt: "Lead the team"},
 			Teammates: []claudev1alpha1.TeammateSpec{
 				{Name: "worker", Model: "sonnet", Prompt: "Do work"},
 			},
@@ -60,8 +60,8 @@ func coworkTeam(name, namespace string) *claudev1alpha1.AgentTeam {
 			Workspace: &claudev1alpha1.WorkspaceSpec{
 				Output: &claudev1alpha1.WorkspaceOutputSpec{Size: "1Gi"},
 			},
-			Auth:  claudev1alpha1.AuthSpec{APIKeySecret: "api-key"},
-			Lead:  claudev1alpha1.LeadSpec{Model: "opus", Prompt: "Lead"},
+			Auth: claudev1alpha1.AuthSpec{APIKeySecret: "api-key"},
+			Lead: claudev1alpha1.LeadSpec{Model: "opus", Prompt: "Lead"},
 			Teammates: []claudev1alpha1.TeammateSpec{
 				{Name: "writer", Model: "sonnet", Prompt: "Write"},
 			},
@@ -494,8 +494,8 @@ var _ = Describe("AgentTeam controller", func() {
 			team.Spec.Teammates = make([]claudev1alpha1.TeammateSpec, 17)
 			for i := range team.Spec.Teammates {
 				team.Spec.Teammates[i] = claudev1alpha1.TeammateSpec{
-					Name:  fmt.Sprintf("tm%02d", i),
-					Model: "sonnet",
+					Name:   fmt.Sprintf("tm%02d", i),
+					Model:  "sonnet",
 					Prompt: "work",
 				}
 			}

--- a/internal/metrics/doc.go
+++ b/internal/metrics/doc.go
@@ -15,12 +15,13 @@
 //   - SetActiveTeams(count int)
 //
 // Metrics:
-//   claude_team_active_total              (Gauge)
-//   claude_team_duration_seconds          (Histogram)   labels: team, namespace
-//   claude_teammate_tokens_total          (Counter)     labels: team, teammate, model
-//   claude_team_cost_usd                  (Gauge)       labels: team, namespace
-//   claude_team_tasks_completed_total     (Counter)     labels: team, teammate
-//   claude_teammate_restarts_total        (Counter)     labels: team, teammate
-//   claude_team_budget_remaining_usd      (Gauge)       labels: team, namespace
-//   claude_teammate_idle_seconds          (Histogram)   labels: team, teammate
+//
+//	claude_team_active_total              (Gauge)
+//	claude_team_duration_seconds          (Histogram)   labels: team, namespace
+//	claude_teammate_tokens_total          (Counter)     labels: team, teammate, model
+//	claude_team_cost_usd                  (Gauge)       labels: team, namespace
+//	claude_team_tasks_completed_total     (Counter)     labels: team, teammate
+//	claude_teammate_restarts_total        (Counter)     labels: team, teammate
+//	claude_team_budget_remaining_usd      (Gauge)       labels: team, namespace
+//	claude_teammate_idle_seconds          (Histogram)   labels: team, teammate
 package metrics

--- a/internal/webhook/doc.go
+++ b/internal/webhook/doc.go
@@ -19,11 +19,12 @@
 //   - "team.timedout"    — Team exceeded timeout
 //
 // Payload format (JSON):
-//   {
-//     "event": "task.completed",
-//     "team": "auth-refactor",
-//     "namespace": "dev-agents",
-//     "timestamp": "2026-04-03T14:30:00Z",
-//     "data": { ... event-specific fields ... }
-//   }
+//
+//	{
+//	  "event": "task.completed",
+//	  "team": "auth-refactor",
+//	  "namespace": "dev-agents",
+//	  "timestamp": "2026-04-03T14:30:00Z",
+//	  "data": { ... event-specific fields ... }
+//	}
 package webhook


### PR DESCRIPTION
## Summary

- **+14 unit tests** covering previously untested failure scenarios — unit test count goes from 36 → 50
- **Bug fix:** `allPodsComplete` was silently ignoring a failed teammate while the lead pod was still running (short-circuit on lead-not-done). Now does a full scan of all pods in one pass.
- **Bug fix:** `reconcileInitializing` had no timeout check. A hung init Job could leave a team permanently stuck in `Initializing` past its configured `lifecycle.timeout`. Fixed by checking `isTimedOut` at the top of that phase.
- Fixed leftover `ghcr.io/camlabs/...` reference in `defaultAgentImage` constant.

### New tests added

| Category | Tests |
|----------|-------|
| Terminal phase | `StampsCompletedAt`, `Idempotent`, `DeletesRunningPods` |
| Timeout/budget cleanup | `Timeout_TerminatesPods`, `BudgetExceeded_TerminatesPods` |
| Running edge cases | `TeammateFailure_SetsFailedPhase`, `LeadNotSpawned_KeepsRunning` |
| Initializing edge cases | `InitJobMissing_Waits`, `HangingInitJob_TimesOut` |
| Dependency logic | `DepFailed_NotMet`, `AllMustSucceed` |
| Pod builder | `OAuthAuth`, `AgentCommandOverride` |
| Status sync | `SyncPodStatuses_ReflectsPodPhases` |

## Test plan

- [x] `make test` — 50/50 unit tests pass
- [x] `make test-integration` — 25/25 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)