### PR TITLE
test(integration): cover Cowork pod deployment and terminal cleanup (#30)

### DIFF
--- a/internal/controller/agentteam_integration_test.go
+++ b/internal/controller/agentteam_integration_test.go
@@ -287,6 +287,27 @@ var _ = Describe("AgentTeam controller", func() {
 			Expect(k8sClient.Get(ctx, nn(team.Name+"-init", namespace),
 				&batchv1.Job{})).To(MatchError(errors.IsNotFound, "IsNotFound"))
 		})
+
+		It("deploys lead and teammate pods with no repo volume or WORKTREE_PATH", func() {
+			waitForPhase(team.Name, namespace, "Running")
+			waitForPod(team.Name+"-lead", namespace)
+			waitForPod(team.Name+"-writer", namespace)
+
+			// Verify no repo volume is mounted on either pod.
+			for _, podName := range []string{team.Name + "-lead", team.Name + "-writer"} {
+				var pod corev1.Pod
+				Expect(k8sClient.Get(ctx, nn(podName, namespace), &pod)).To(Succeed())
+
+				volumeNames := []string{}
+				for _, v := range pod.Spec.Volumes {
+					volumeNames = append(volumeNames, v.Name)
+				}
+				Expect(volumeNames).NotTo(ContainElement("repo"), "cowork pod %s should not have a repo volume", podName)
+
+				env := envMap(pod)
+				Expect(env).NotTo(HaveKey("WORKTREE_PATH"), "cowork pod %s should not have WORKTREE_PATH", podName)
+			}
+		})
 	})
 
 	Describe("Initializing phase — coding mode", func() {
@@ -404,6 +425,34 @@ var _ = Describe("AgentTeam controller", func() {
 				g.Expect(t.Status.Lead).NotTo(BeNil())
 				g.Expect(t.Status.Lead.Phase).To(Equal("Completed"))
 			}).Should(Succeed())
+		})
+
+		It("deletes all team pods during terminal phase and sets a stable completedAt", func() {
+			succeedPod(team.Name+"-lead", namespace)
+			succeedPod(team.Name+"-worker", namespace)
+			waitForPhase(team.Name, namespace, "Completed")
+
+			// Verify reconcileTerminal deletes the pods.
+			expectPodGone(team.Name+"-lead", namespace)
+			expectPodGone(team.Name+"-worker", namespace)
+
+			// Verify completedAt is set and stable across reconciles.
+			var first metav1.Time
+			Eventually(func(g Gomega) {
+				var t claudev1alpha1.AgentTeam
+				g.Expect(k8sClient.Get(ctx, nn(team.Name, namespace), &t)).To(Succeed())
+				g.Expect(t.Status.CompletedAt).NotTo(BeNil())
+				first = *t.Status.CompletedAt
+			}).Should(Succeed())
+
+			// Poke to trigger another reconcile and confirm completedAt does not change.
+			pokeTeam(team.Name, namespace)
+			Consistently(func(g Gomega) {
+				var t claudev1alpha1.AgentTeam
+				g.Expect(k8sClient.Get(ctx, nn(team.Name, namespace), &t)).To(Succeed())
+				g.Expect(t.Status.CompletedAt).NotTo(BeNil())
+				g.Expect(t.Status.CompletedAt.Time).To(Equal(first.Time), "completedAt should be stable across reconciles")
+			}).WithTimeout(3 * time.Second).Should(Succeed())
 		})
 	})
 


### PR DESCRIPTION
## Summary
- Adds 2 new envtest integration specs closing gaps in Cowork mode and terminal phase coverage
- **Cowork pod deployment**: verifies lead + teammate pods are created when a Cowork team reaches Running, and that neither pod has a repo volume or `WORKTREE_PATH` env var (the key behavioral difference from coding mode)
- **Terminal cleanup**: after all pods succeed and the team reaches Completed, verifies `reconcileTerminal` deletes all team pods and stamps `completedAt` exactly once — a second reconcile leaves it unchanged

Stacked on #77 (test/integration-timeout-budget).

## Test plan
- [x] `make test-integration` — 30/30 specs pass (25 existing + 3 from #29 + 2 new)
- [x] `make test` — unit tests green, 87.7% coverage

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)