### PR TITLE
fix(ci): restrict monthly-dependency-release to schedule/dispatch only

### DIFF
--- a/.github/workflows/monthly-dependency-release.yml
+++ b/.github/workflows/monthly-dependency-release.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   open-release-pr:
     name: Open patch release PR
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- GitHub Actions evaluates new workflow files on push regardless of declared triggers, causing the monthly release workflow to fire (and fail) on every branch push
- Adds a job-level `if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'` guard so the job is skipped on push events

## Test plan
- [x] Verified the workflow YAML is valid
- [ ] Next push to any branch should show the job as skipped instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)