### PR TITLE
fix(ci): skip commit lint on release PRs targeting main

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -117,7 +117,7 @@ jobs:
   commit-lint:
     name: Commit Lint
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.base_ref != 'main'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## Summary
- Skip the commit lint job when the PR targets `main` (release promotions)
- The develop→main PR includes the full commit history since the initial scaffold commit, which pre-dates conventional commits
- Commit lint remains active for all feature PRs targeting `develop`

## Test plan
- [ ] PR #80 (release v0.1.0) should no longer be blocked by commit lint after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)