### PR TITLE
fix(ci): add nfs StorageClass alias to acceptance workflow

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -49,6 +49,21 @@ jobs:
       - name: Generate manifests
         run: make manifests
 
+      # Kind uses local-path-provisioner with a 'standard' StorageClass.
+      # The operator defaults team-state and repo PVCs to StorageClass 'nfs',
+      # so create an alias backed by the same provisioner.
+      - name: Create nfs StorageClass alias for Kind
+        run: |
+          kubectl apply -f - <<'YAML'
+          apiVersion: storage.k8s.io/v1
+          kind: StorageClass
+          metadata:
+            name: nfs
+          provisioner: rancher.io/local-path
+          reclaimPolicy: Delete
+          volumeBindingMode: WaitForFirstConsumer
+          YAML
+
       - name: Install CRDs
         run: kubectl apply -f config/crd/bases/
 


### PR DESCRIPTION
## Summary
- The CI acceptance workflow was missing the `nfs` StorageClass alias that `hack/acceptance-setup.sh` creates locally
- Without it, the operator's team-state PVCs (which default to StorageClass `nfs`) never bind in Kind
- Pods stay stuck in ContainerCreating → lifecycle tests time out after 3 minutes

This is why the Cowork lifecycle "reaches Completed" and "stamps completedAt" specs failed in PR #82.

## Test plan
- [ ] PR #82 acceptance tests should pass after this merges and the release PR is re-created

🤖 Generated with [Claude Code](https://claude.com/claude-code)