### PR TITLE
ci: add runner image build to CI and release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,31 @@ jobs:
           provenance: true
           sbom: true
 
+      - name: Extract Docker metadata (runner)
+        id: meta-runner
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
+        with:
+          images: ghcr.io/amcheste/claude-code-runner
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=sha-
+
+      - name: Build and push runner image
+        id: build-runner
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: .
+          file: docker/Dockerfile.claude-code
+          push: true
+          tags: ${{ steps.meta-runner.outputs.tags }}
+          labels: ${{ steps.meta-runner.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3
 
@@ -68,6 +93,11 @@ jobs:
         run: |
           cosign sign --yes \
             ghcr.io/amcheste/claude-teams-operator@${{ steps.build-operator.outputs.digest }}
+
+      - name: Sign runner image with Sigstore keyless
+        run: |
+          cosign sign --yes \
+            ghcr.io/amcheste/claude-code-runner@${{ steps.build-runner.outputs.digest }}
 
   # ── Create GitHub Release ─────────────────────────────────────────────────
   release:
@@ -113,11 +143,16 @@ jobs:
 
             ```
             ghcr.io/amcheste/claude-teams-operator:${{ github.ref_name }}
+            ghcr.io/amcheste/claude-code-runner:${{ github.ref_name }}
             ```
 
             Images are signed with [Sigstore Cosign](https://docs.sigstore.dev/) (keyless). Verify with:
             ```bash
             cosign verify ghcr.io/amcheste/claude-teams-operator:${{ github.ref_name }} \
+              --certificate-identity-regexp="https://github.com/amcheste/claude-teams-operator" \
+              --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
+
+            cosign verify ghcr.io/amcheste/claude-code-runner:${{ github.ref_name }} \
               --certificate-identity-regexp="https://github.com/amcheste/claude-teams-operator" \
               --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
             ```

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -113,6 +113,9 @@ jobs:
       - name: Build operator Docker image
         run: docker build -f docker/Dockerfile.operator -t claude-teams-operator:ci .
 
+      - name: Build runner Docker image
+        run: docker build -f docker/Dockerfile.claude-code -t claude-code-runner:ci .
+
   # ── Commit Lint (PRs only) ────────────────────────────────────────────────
   commit-lint:
     name: Commit Lint

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # claude-teams-operator Makefile
 
-IMG ?= ghcr.io/camlabs/claude-teams-operator:latest
-CLAUDE_CODE_IMG ?= ghcr.io/camlabs/claude-code-runner:latest
+IMG ?= ghcr.io/amcheste/claude-teams-operator:latest
+CLAUDE_CODE_IMG ?= ghcr.io/amcheste/claude-code-runner:latest
 KIND_CLUSTER_NAME ?= claude-teams
 
 # Tool versions

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -41,7 +41,7 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false, "Enable leader election for controller manager.")
-	flag.StringVar(&agentImage, "agent-image", "", "Override the container image used for agent pods (default: ghcr.io/camlabs/claude-code-runner:latest).")
+	flag.StringVar(&agentImage, "agent-image", "", "Override the container image used for agent pods (default: ghcr.io/amcheste/claude-code-runner:latest).")
 	flag.StringVar(&initImage, "init-image", "", "Override the container image used for the repo init Job (default: alpine/git:latest).")
 	flag.BoolVar(&skipInitScript, "skip-init-script", false, "Replace the init Job git-clone script with a no-op exit 0. Use in acceptance tests where no real repo is available.")
 	flag.StringVar(&pvcAccessMode, "pvc-access-mode", "", "Override PVC access mode for all operator-managed PVCs (ReadWriteMany|ReadWriteOnce). Defaults to ReadWriteMany. Set to ReadWriteOnce for single-node clusters like Kind.")


### PR DESCRIPTION
## Summary

- Add `claude-code-runner` image build step to the **validate** workflow so the runner Dockerfile is verified on every PR
- Add `claude-code-runner` image build, push, and Cosign signing to the **release** workflow so it's published alongside the operator on tagged releases
- Fix stale `ghcr.io/camlabs/` references → `ghcr.io/amcheste/` in Makefile and `--agent-image` flag help text
- Update release notes template to list both container images with verification commands

Closes #4

## Changes

| File | What |
|------|------|
| `.github/workflows/validate.yml` | Add runner image build step to the `build` job |
| `.github/workflows/release.yml` | Add metadata extraction, build+push, and Cosign signing for runner image; update release notes body |
| `Makefile` | Fix `IMG` and `CLAUDE_CODE_IMG` from `ghcr.io/camlabs/` → `ghcr.io/amcheste/` |
| `cmd/manager/main.go` | Fix `--agent-image` flag help text reference |

## Test plan

- [x] `docker build -f docker/Dockerfile.claude-code .` succeeds locally
- [x] Verified `claude` CLI is installed and resolves model/permission flags correctly inside the container
- [x] `go vet ./...` passes
- [x] `make test` passes (all unit tests)
- [ ] CI validates the runner image builds on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)