### PR TITLE
test: add mailbox file exchange smoke test on shared PVC (#6)

### DIFF
--- a/KUBECON.md
+++ b/KUBECON.md
@@ -99,6 +99,8 @@ Acknowledging this honestly makes the talk more credible. Frame it as: "here's t
 What happened, what you tried, what you decided. One paragraph is enough.
 -->
 
+### 2026-04-14 Proving RWX without an RWX provisioner
+The mailbox-exchange claim (`~/.claude/teams/{team}/inboxes/{agent}.json` visible across two pods) needed a smoke test we could run anywhere, including single-node Kind. The real blocker is that Kind's built-in `local-path-provisioner` only exposes ReadWriteOnce — it literally cannot advertise RWX. The acceptance setup works around this with a StorageClass alias named `nfs` that points back at `rancher.io/local-path`, giving PVCs the *name* they expect while leaning on the fact that on a single-node cluster every pod runs on the same node, so a hostPath volume is visible to every pod simultaneously. That is not "true" RWX — it's a coincidence of topology that makes RWX-semantics tests pass. The trade-off for the talk: we can prove the *architectural claim* (file-based coordination works when pods share a mount) on any laptop, but must label real multi-node deployments as requiring an actual RWX backend (NFS, EFS, Filestore, etc.). The smoke test (`hack/mailbox-smoke-test.sh`) runs against whatever the cluster offers and reports the effective access mode in its PASS line so this distinction doesn't get lost.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,10 @@ acceptance-up: ## Create Kind cluster and deploy operator in acceptance mode (bu
 acceptance-down: ## Tear down Kind acceptance cluster
 	kind delete cluster --name $(KIND_CLUSTER_NAME)
 
+.PHONY: mailbox-smoke-test
+mailbox-smoke-test: ## Validate mailbox file exchange on shared PVC (requires acceptance-up or any cluster with an 'nfs' StorageClass)
+	bash hack/mailbox-smoke-test.sh
+
 .PHONY: envtest
 envtest: ## Install setup-envtest
 	@test -f $(SETUP_ENVTEST) || go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest

--- a/hack/mailbox-smoke-test.sh
+++ b/hack/mailbox-smoke-test.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# hack/mailbox-smoke-test.sh
+#
+# Proves the core architectural claim of the operator: two pods sharing a
+# ReadWriteMany PVC can exchange JSON mailbox files as Claude Code's native
+# Agent Teams protocol expects.
+#
+# The script creates a PVC that matches the operator's team-state PVC
+# (same StorageClass, size, and mount path) and spawns two long-lived busybox
+# pods in the role of lead + teammate. It then:
+#   1. writes an inbox JSON from the lead pod
+#   2. reads it back from the teammate pod
+#   3. writes a reply from the teammate pod
+#   4. reads the reply back from the lead pod
+#
+# Bypassing the AgentTeam CRD here is deliberate: the acceptance-mode operator
+# spawns pods with a 20-second lifetime which does not leave room for reliable
+# kubectl-exec round-trips. This script isolates the PVC + mount behaviour that
+# is the real subject of the test. The operator's own PVC creation is already
+# covered by the Ginkgo acceptance suite (waitForPVC assertions).
+#
+# Usage:
+#   make acceptance-up          # or any Kind cluster with an 'nfs' StorageClass
+#   bash hack/mailbox-smoke-test.sh
+#
+# Requires: kubectl, a reachable Kubernetes cluster, the 'nfs' StorageClass
+# alias that the operator expects (created by hack/acceptance-setup.sh).
+
+set -euo pipefail
+
+# Extend PATH to pick up Homebrew / Docker Desktop binaries when run outside
+# an interactive shell.
+export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH}"
+
+CLUSTER_NAME="${KIND_CLUSTER_NAME:-claude-teams}"
+TEST_NS="mailbox-smoke-$(date +%s)"
+TEAM_NAME="mailbox-demo"
+PVC_NAME="${TEAM_NAME}-team-state"
+PVC_SIZE="${PVC_SIZE:-1Gi}"
+STORAGE_CLASS="${STORAGE_CLASS:-nfs}"
+# Kind's local-path provisioner only supports RWO. The script still proves
+# the architectural claim on single-node clusters because hostPath volumes are
+# visible to every pod on that node. Override with RWM on a real cluster.
+PVC_ACCESS_MODE="${PVC_ACCESS_MODE:-ReadWriteOnce}"
+MOUNT_PATH="/var/claude-state"
+READY_TIMEOUT_SEC="${READY_TIMEOUT_SEC:-120}"
+
+log() { echo "==> $*"; }
+fail() { echo "[FAIL] $*" >&2; exit 1; }
+
+cleanup() {
+  local rc=$?
+  log "Cleaning up namespace ${TEST_NS}"
+  kubectl delete namespace "${TEST_NS}" --wait=false --ignore-not-found >/dev/null 2>&1 || true
+  exit "${rc}"
+}
+trap cleanup EXIT
+
+# ── Preflight ──────────────────────────────────────────────────────────────
+log "Verifying cluster connectivity"
+if ! kubectl cluster-info >/dev/null 2>&1; then
+  fail "No reachable cluster. Run 'make acceptance-up' first."
+fi
+
+log "Verifying '${STORAGE_CLASS}' StorageClass exists"
+if ! kubectl get storageclass "${STORAGE_CLASS}" >/dev/null 2>&1; then
+  fail "StorageClass '${STORAGE_CLASS}' not found. Run 'make acceptance-up' first or set STORAGE_CLASS=<name>."
+fi
+
+# ── Create test namespace and PVC ──────────────────────────────────────────
+log "Creating namespace ${TEST_NS}"
+kubectl create namespace "${TEST_NS}" >/dev/null
+
+log "Creating team-state PVC ${PVC_NAME} (${PVC_ACCESS_MODE}, ${PVC_SIZE}, storageClass=${STORAGE_CLASS})"
+kubectl apply -n "${TEST_NS}" -f - <<YAML >/dev/null
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${PVC_NAME}
+spec:
+  accessModes: ["${PVC_ACCESS_MODE}"]
+  storageClassName: ${STORAGE_CLASS}
+  resources:
+    requests:
+      storage: ${PVC_SIZE}
+YAML
+
+# ── Deploy lead + teammate pods ────────────────────────────────────────────
+deploy_pod() {
+  local name="$1"
+  kubectl apply -n "${TEST_NS}" -f - <<YAML >/dev/null
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${name}
+  labels:
+    app: mailbox-smoke
+    role: ${name}
+spec:
+  restartPolicy: Never
+  containers:
+    - name: agent
+      image: busybox:latest
+      command: ["sh", "-c", "sleep 600"]
+      volumeMounts:
+        - name: team-state
+          mountPath: ${MOUNT_PATH}
+  volumes:
+    - name: team-state
+      persistentVolumeClaim:
+        claimName: ${PVC_NAME}
+YAML
+}
+
+log "Deploying lead pod"
+deploy_pod "${TEAM_NAME}-lead"
+log "Deploying teammate pod"
+deploy_pod "${TEAM_NAME}-teammate"
+
+wait_for_ready() {
+  local pod="$1"
+  log "Waiting up to ${READY_TIMEOUT_SEC}s for pod ${pod} to be Ready"
+  if ! kubectl wait -n "${TEST_NS}" --for=condition=Ready "pod/${pod}" --timeout="${READY_TIMEOUT_SEC}s" >/dev/null; then
+    kubectl -n "${TEST_NS}" describe "pod/${pod}" >&2 || true
+    fail "pod ${pod} did not become Ready within ${READY_TIMEOUT_SEC}s"
+  fi
+}
+
+wait_for_ready "${TEAM_NAME}-lead"
+wait_for_ready "${TEAM_NAME}-teammate"
+
+# ── Exchange mailbox files ─────────────────────────────────────────────────
+INBOX_DIR="${MOUNT_PATH}/teams/${TEAM_NAME}/inboxes"
+LEAD_MESSAGE='{"from":"lead","to":"teammate","subject":"ping","body":"mailbox exchange verified lead->teammate"}'
+TEAMMATE_REPLY='{"from":"teammate","to":"lead","subject":"pong","body":"mailbox exchange verified teammate->lead"}'
+
+log "Writing inbox JSON from lead pod"
+kubectl -n "${TEST_NS}" exec "${TEAM_NAME}-lead" -- sh -c \
+  "mkdir -p ${INBOX_DIR} && printf '%s' '${LEAD_MESSAGE}' > ${INBOX_DIR}/teammate.json"
+
+log "Reading inbox JSON from teammate pod"
+READ_BY_TEAMMATE="$(kubectl -n "${TEST_NS}" exec "${TEAM_NAME}-teammate" -- cat "${INBOX_DIR}/teammate.json")"
+
+if [[ "${READ_BY_TEAMMATE}" != "${LEAD_MESSAGE}" ]]; then
+  echo "expected: ${LEAD_MESSAGE}" >&2
+  echo "got:      ${READ_BY_TEAMMATE}" >&2
+  fail "teammate pod could not read the message written by lead"
+fi
+log "  ✓ teammate sees lead's message"
+
+log "Writing reply from teammate pod"
+kubectl -n "${TEST_NS}" exec "${TEAM_NAME}-teammate" -- sh -c \
+  "mkdir -p ${INBOX_DIR} && printf '%s' '${TEAMMATE_REPLY}' > ${INBOX_DIR}/lead.json"
+
+log "Reading reply from lead pod"
+READ_BY_LEAD="$(kubectl -n "${TEST_NS}" exec "${TEAM_NAME}-lead" -- cat "${INBOX_DIR}/lead.json")"
+
+if [[ "${READ_BY_LEAD}" != "${TEAMMATE_REPLY}" ]]; then
+  echo "expected: ${TEAMMATE_REPLY}" >&2
+  echo "got:      ${READ_BY_LEAD}" >&2
+  fail "lead pod could not read the reply written by teammate"
+fi
+log "  ✓ lead sees teammate's reply"
+
+# ── Verify directory listing from each side ────────────────────────────────
+log "Verifying both pods see the complete inbox directory"
+LEAD_LISTING="$(kubectl -n "${TEST_NS}" exec "${TEAM_NAME}-lead" -- ls "${INBOX_DIR}" | sort | tr '\n' ' ')"
+TEAMMATE_LISTING="$(kubectl -n "${TEST_NS}" exec "${TEAM_NAME}-teammate" -- ls "${INBOX_DIR}" | sort | tr '\n' ' ')"
+
+if [[ "${LEAD_LISTING}" != "${TEAMMATE_LISTING}" ]]; then
+  echo "lead     sees: ${LEAD_LISTING}" >&2
+  echo "teammate sees: ${TEAMMATE_LISTING}" >&2
+  fail "pods disagree on inbox directory contents"
+fi
+
+if [[ "${LEAD_LISTING}" != "lead.json teammate.json " ]]; then
+  fail "unexpected inbox listing (got: '${LEAD_LISTING}')"
+fi
+log "  ✓ both pods see: ${LEAD_LISTING}"
+
+echo ""
+log "PASS — mailbox file exchange verified on shared PVC"
+log "      StorageClass=${STORAGE_CLASS} AccessMode=${PVC_ACCESS_MODE} Mount=${MOUNT_PATH}"


### PR DESCRIPTION
## Summary
- Adds `hack/mailbox-smoke-test.sh`: a standalone smoke test that proves the core architectural claim — two pods sharing a PVC can exchange Claude Code Agent Teams mailbox JSON files (`~/.claude/teams/{team}/inboxes/{agent}.json`). Mirrors the operator's team-state PVC spec (StorageClass `nfs`, size, mount path `/var/claude-state`), spawns a lead + teammate busybox pair, and verifies bidirectional exchange plus identical directory listings.
- Adds `make mailbox-smoke-test` target.
- Logs the RWX-in-Kind trade-off in `KUBECON.md` under "Interesting Problems Encountered" for the talk narrative.

Closes #6.

## Why a bash script instead of an AgentTeam CR
The acceptance-mode operator spawns pods with a ~20-second lifetime (busybox `sleep 20 && exit 0`), which is too tight for reliable `kubectl exec` round-trips. This script isolates the PVC + mount behaviour that is the real subject of the test. Operator PVC provisioning is already covered by the Ginkgo acceptance suite (`waitForPVC` assertions).

## RWX on single-node Kind
Kind's built-in `local-path-provisioner` can only advertise RWO. The acceptance setup works around this with a `nfs` StorageClass alias pointing back at `rancher.io/local-path`, relying on the fact that every pod on a single-node cluster shares the same hostPath mount. That is not "true" RWX — it's a topology coincidence — but it's enough to prove the architectural claim on a laptop. On real multi-node clusters, override with:
```
PVC_ACCESS_MODE=ReadWriteMany STORAGE_CLASS=<real-rwx-sc> make mailbox-smoke-test
```
The PASS line reports the effective access mode so the distinction is visible.

## Test plan
- [x] Script passes on Kind with `make acceptance-up` + `make mailbox-smoke-test`
- [x] Runs cleanly via `bash hack/mailbox-smoke-test.sh` directly
- [x] Output confirms: `PASS — mailbox file exchange verified on shared PVC, StorageClass=nfs AccessMode=ReadWriteOnce Mount=/var/claude-state`
- [x] Cleanup trap removes the test namespace on exit