### PR TITLE
feat: make `kubectl describe agentteam` talk-ready (#7)

### DIFF
--- a/api/v1alpha1/agentteam_types.go
+++ b/api/v1alpha1/agentteam_types.go
@@ -395,6 +395,11 @@ type AgentTeamStatus struct {
 	// EstimatedCost is the estimated API cost in USD (e.g. "4.50").
 	EstimatedCost string `json:"estimatedCost,omitempty"`
 
+	// Ready reports how many teammate pods are ready vs. declared, in the form
+	// "running+completed/total" (e.g. "3/5"). Shown in `kubectl get` output.
+	// +optional
+	Ready string `json:"ready,omitempty"`
+
 	// Lead reports the team lead's status.
 	// +optional
 	Lead *AgentStatus `json:"lead,omitempty"`
@@ -463,7 +468,7 @@ type PullRequestStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
-// +kubebuilder:printcolumn:name="Teammates",type=integer,JSONPath=`.status.tasks.total`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.ready`
 // +kubebuilder:printcolumn:name="Tasks Done",type=integer,JSONPath=`.status.tasks.completed`
 // +kubebuilder:printcolumn:name="Cost",type=string,JSONPath=`.status.estimatedCost`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`

--- a/config/crd/bases/claude.amcheste.io_agentteamruns.yaml
+++ b/config/crd/bases/claude.amcheste.io_agentteamruns.yaml
@@ -468,6 +468,11 @@ spec:
                   url:
                     type: string
                 type: object
+              ready:
+                description: |-
+                  Ready reports how many teammate pods are ready vs. declared, in the form
+                  "running+completed/total" (e.g. "3/5"). Shown in `kubectl get` output.
+                type: string
               startedAt:
                 description: StartedAt is when the team began execution.
                 format: date-time

--- a/config/crd/bases/claude.amcheste.io_agentteams.yaml
+++ b/config/crd/bases/claude.amcheste.io_agentteams.yaml
@@ -18,9 +18,9 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
-    - jsonPath: .status.tasks.total
-      name: Teammates
-      type: integer
+    - jsonPath: .status.ready
+      name: Ready
+      type: string
     - jsonPath: .status.tasks.completed
       name: Tasks Done
       type: integer
@@ -726,6 +726,11 @@ spec:
                   url:
                     type: string
                 type: object
+              ready:
+                description: |-
+                  Ready reports how many teammate pods are ready vs. declared, in the form
+                  "running+completed/total" (e.g. "3/5"). Shown in `kubectl get` output.
+                type: string
               startedAt:
                 description: StartedAt is when the team began execution.
                 format: date-time

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,6 +21,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get

--- a/internal/controller/agentteam_controller.go
+++ b/internal/controller/agentteam_controller.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -54,6 +55,21 @@ type AgentTeamReconciler struct {
 	// Defaults to ReadWriteMany (requires NFS/EFS). Set to ReadWriteOnce for
 	// single-node clusters such as Kind where all pods share the same node.
 	PVCAccessMode corev1.PersistentVolumeAccessMode
+
+	// Recorder emits Kubernetes Events against AgentTeam objects. Populated by
+	// SetupWithManager. Tests may inject a fake recorder directly. The
+	// recordEvent helper tolerates a nil recorder so unit tests that construct
+	// a reconciler directly are not forced to wire one up.
+	Recorder record.EventRecorder
+}
+
+// recordEvent emits an Event against the AgentTeam if a Recorder is configured.
+// eventType is corev1.EventTypeNormal or corev1.EventTypeWarning.
+func (r *AgentTeamReconciler) recordEvent(team *claudev1alpha1.AgentTeam, eventType, reason, messageFmt string, args ...interface{}) {
+	if r.Recorder == nil {
+		return
+	}
+	r.Recorder.Eventf(team, eventType, reason, messageFmt, args...)
 }
 
 func (r *AgentTeamReconciler) pvcAccessMode() corev1.PersistentVolumeAccessMode {
@@ -84,6 +100,7 @@ func (r *AgentTeamReconciler) initImage() string {
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 
 func (r *AgentTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -161,6 +178,7 @@ func (r *AgentTeamReconciler) reconcilePending(ctx context.Context, team *claude
 	now := metav1.Now()
 	team.Status.StartedAt = &now
 	setCondition(team, metav1.ConditionTrue, "Initializing", "PVCs provisioned, init job started")
+	r.recordEvent(team, corev1.EventTypeNormal, "Initializing", "PVCs provisioned; init job started")
 	return ctrl.Result{RequeueAfter: 5 * time.Second}, r.Status().Update(ctx, team)
 }
 
@@ -177,6 +195,7 @@ func (r *AgentTeamReconciler) reconcileInitializing(ctx context.Context, team *c
 		log.Info("Team timed out during initialization")
 		team.Status.Phase = "TimedOut"
 		setCondition(team, metav1.ConditionFalse, "TimedOut", "Team exceeded configured timeout during initialization")
+		r.recordEvent(team, corev1.EventTypeWarning, "TimedOut", "Team exceeded configured timeout during initialization")
 		return ctrl.Result{}, r.Status().Update(ctx, team)
 	}
 
@@ -189,6 +208,7 @@ func (r *AgentTeamReconciler) reconcileInitializing(ctx context.Context, team *c
 		if failed {
 			team.Status.Phase = "Failed"
 			setCondition(team, metav1.ConditionFalse, "InitJobFailed", "Init job exceeded backoff limit")
+			r.recordEvent(team, corev1.EventTypeWarning, "InitJobFailed", "Init job exceeded backoff limit")
 			return ctrl.Result{}, r.Status().Update(ctx, team)
 		}
 		if !done {
@@ -222,6 +242,7 @@ func (r *AgentTeamReconciler) reconcileInitializing(ctx context.Context, team *c
 
 	team.Status.Phase = "Running"
 	setCondition(team, metav1.ConditionTrue, "Running", "Agent pods deployed")
+	r.recordEvent(team, corev1.EventTypeNormal, "Running", "Agent pods deployed")
 	return ctrl.Result{RequeueAfter: 30 * time.Second}, r.Status().Update(ctx, team)
 }
 
@@ -240,6 +261,7 @@ func (r *AgentTeamReconciler) reconcileRunning(ctx context.Context, team *claude
 		}
 		team.Status.Phase = "TimedOut"
 		setCondition(team, metav1.ConditionFalse, "TimedOut", "Team exceeded configured timeout")
+		r.recordEvent(team, corev1.EventTypeWarning, "TimedOut", "Team exceeded configured timeout; all pods terminated")
 		return ctrl.Result{}, r.Status().Update(ctx, team)
 	}
 
@@ -252,6 +274,7 @@ func (r *AgentTeamReconciler) reconcileRunning(ctx context.Context, team *claude
 		}
 		team.Status.Phase = "BudgetExceeded"
 		setCondition(team, metav1.ConditionFalse, "BudgetExceeded", "Estimated cost exceeded budget limit")
+		r.recordEvent(team, corev1.EventTypeWarning, "BudgetExceeded", "Estimated cost %s exceeded budget limit; all pods terminated", team.Status.EstimatedCost)
 		return ctrl.Result{}, r.Status().Update(ctx, team)
 	}
 
@@ -292,6 +315,7 @@ func (r *AgentTeamReconciler) reconcileRunning(ctx context.Context, team *claude
 	if anyFailed {
 		team.Status.Phase = "Failed"
 		setCondition(team, metav1.ConditionFalse, "AgentFailed", "One or more agent pods failed")
+		r.recordEvent(team, corev1.EventTypeWarning, "AgentFailed", "One or more agent pods failed")
 		return ctrl.Result{}, r.Status().Update(ctx, team)
 	}
 	if allDone {
@@ -302,6 +326,7 @@ func (r *AgentTeamReconciler) reconcileRunning(ctx context.Context, team *claude
 		}
 		team.Status.Phase = "Completed"
 		setCondition(team, metav1.ConditionFalse, "Completed", "All agents finished successfully")
+		r.recordEvent(team, corev1.EventTypeNormal, "Completed", "All agents finished successfully")
 		return ctrl.Result{}, r.Status().Update(ctx, team)
 	}
 
@@ -766,7 +791,18 @@ func (r *AgentTeamReconciler) buildAgentPod(
 
 // --- Status Sync ---
 
-// syncPodStatuses reads pod phases and updates team.Status.Lead and team.Status.Teammates.
+// syncPodStatuses refreshes team.Status.Lead and team.Status.Teammates from
+// current pod phases and computes team.Status.Ready ("running+completed/total").
+// Every teammate declared in the spec is ensured a status entry — even before
+// its pod is scheduled (dependsOn, approval gate, or first reconcile) — so
+// `kubectl describe` surfaces the full roster with a "Waiting" phase for
+// anything not yet deployed.
+//
+// TasksCompleted, TasksClaimed, and PendingApproval are preserved across
+// reconciles; they are populated by the approval-gate helpers and will be
+// filled from the shared task list in a later milestone. Transient API
+// errors when fetching a teammate pod leave the existing phase untouched
+// rather than clobbering it with "Waiting".
 func (r *AgentTeamReconciler) syncPodStatuses(ctx context.Context, team *claudev1alpha1.AgentTeam) {
 	// Lead pod.
 	leadPod := &corev1.Pod{}
@@ -778,25 +814,38 @@ func (r *AgentTeamReconciler) syncPodStatuses(ctx context.Context, team *claudev
 		team.Status.Lead.Phase = podPhaseToAgentPhase(leadPod)
 	}
 
-	// Teammate pods.
-	statusMap := map[string]*claudev1alpha1.TeammateStatus{}
-	for i := range team.Status.Teammates {
-		statusMap[team.Status.Teammates[i].Name] = &team.Status.Teammates[i]
+	// Preserve existing non-pod fields (TasksCompleted/Claimed, PendingApproval)
+	// across the rebuild below.
+	prev := map[string]claudev1alpha1.TeammateStatus{}
+	for _, st := range team.Status.Teammates {
+		prev[st.Name] = st
 	}
+
+	rebuilt := make([]claudev1alpha1.TeammateStatus, 0, len(team.Spec.Teammates))
+	ready := 0
 	for _, tm := range team.Spec.Teammates {
+		st := prev[tm.Name]
+		st.Name = tm.Name
+
 		pod := &corev1.Pod{}
-		if err := r.Get(ctx, types.NamespacedName{Name: agentPodName(team, tm.Name), Namespace: team.Namespace}, pod); err != nil {
-			continue
+		err := r.Get(ctx, types.NamespacedName{Name: agentPodName(team, tm.Name), Namespace: team.Namespace}, pod)
+		switch {
+		case err == nil:
+			st.PodName = pod.Name
+			st.Phase = podPhaseToAgentPhase(pod)
+		case errors.IsNotFound(err):
+			st.PodName = ""
+			st.Phase = "Waiting"
 		}
-		st, ok := statusMap[tm.Name]
-		if !ok {
-			team.Status.Teammates = append(team.Status.Teammates, claudev1alpha1.TeammateStatus{Name: tm.Name})
-			st = &team.Status.Teammates[len(team.Status.Teammates)-1]
-			statusMap[tm.Name] = st
+		// On other (transient) errors, leave st.Phase and st.PodName as-is.
+
+		if st.Phase == "Running" || st.Phase == "Completed" {
+			ready++
 		}
-		st.PodName = pod.Name
-		st.Phase = podPhaseToAgentPhase(pod)
+		rebuilt = append(rebuilt, st)
 	}
+	team.Status.Teammates = rebuilt
+	team.Status.Ready = fmt.Sprintf("%d/%d", ready, len(team.Spec.Teammates))
 }
 
 func podPhaseToAgentPhase(pod *corev1.Pod) string {
@@ -1130,6 +1179,9 @@ func boolPtr(b bool) *bool { return &b }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AgentTeamReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.Recorder == nil {
+		r.Recorder = mgr.GetEventRecorderFor("agentteam-controller")
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&claudev1alpha1.AgentTeam{}).
 		Owns(&corev1.Pod{}).

--- a/internal/controller/agentteam_controller_test.go
+++ b/internal/controller/agentteam_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1646,4 +1648,178 @@ func mountPaths(pod *corev1.Pod) []string {
 		paths[i] = m.MountPath
 	}
 	return paths
+}
+
+// drainFakeRecorder reads everything currently sitting in the FakeRecorder's
+// channel into a slice. FakeRecorder's channel is buffered — events arrive
+// synchronously from Eventf — so a single non-blocking drain after a reconcile
+// call gives us everything emitted by that call.
+func drainFakeRecorder(r *record.FakeRecorder) []string {
+	var events []string
+	for {
+		select {
+		case e := <-r.Events:
+			events = append(events, e)
+		default:
+			return events
+		}
+	}
+}
+
+// --- syncPodStatuses (extended behavior) ---
+
+// TestSyncPodStatuses_EnsuresEntryForEveryTeammate verifies that every spec
+// teammate gets a TeammateStatus entry even before its pod is scheduled —
+// critical for `kubectl describe` to surface the full roster during startup.
+func TestSyncPodStatuses_EnsuresEntryForEveryTeammate(t *testing.T) {
+	team := minimalTeam("sync-empty")
+	team.Spec.Teammates = append(team.Spec.Teammates, claudev1alpha1.TeammateSpec{
+		Name: "reviewer", Model: "sonnet", Prompt: "Review the work",
+	})
+	r := newReconciler(team) // no pods at all
+	team = fetch(t, r, "sync-empty")
+
+	r.syncPodStatuses(context.Background(), team)
+
+	require.Len(t, team.Status.Teammates, 2, "every spec teammate must surface in status even pre-pod")
+	assert.Equal(t, "worker", team.Status.Teammates[0].Name)
+	assert.Equal(t, "Waiting", team.Status.Teammates[0].Phase)
+	assert.Empty(t, team.Status.Teammates[0].PodName, "pre-pod teammate must not carry a PodName")
+	assert.Equal(t, "reviewer", team.Status.Teammates[1].Name)
+	assert.Equal(t, "Waiting", team.Status.Teammates[1].Phase)
+}
+
+// TestSyncPodStatuses_ComputesReadyString verifies Ready is populated as
+// "running+completed/total" — the value rendered in the `kubectl get` Ready
+// column and the talk-ready demo.
+func TestSyncPodStatuses_ComputesReadyString(t *testing.T) {
+	team := minimalTeam("sync-ready")
+	team.Spec.Teammates = append(team.Spec.Teammates,
+		claudev1alpha1.TeammateSpec{Name: "reviewer", Model: "sonnet", Prompt: "Review"},
+		claudev1alpha1.TeammateSpec{Name: "idle", Model: "sonnet", Prompt: "Idle"},
+	)
+	workerPod := runningPod("sync-ready-worker", "default", "sync-ready")
+	reviewerPod := succeededPod("sync-ready-reviewer", "default", "sync-ready")
+	// 'idle' teammate has no pod → Waiting, not counted.
+	r := newReconciler(team, workerPod, reviewerPod)
+	team = fetch(t, r, "sync-ready")
+
+	r.syncPodStatuses(context.Background(), team)
+
+	assert.Equal(t, "2/3", team.Status.Ready,
+		"Ready must count Running+Completed teammates against the spec total")
+}
+
+// TestSyncPodStatuses_PreservesPendingApproval verifies that re-syncing does
+// not clobber non-pod fields like PendingApproval that are populated by the
+// approval-gate helpers on a separate code path.
+func TestSyncPodStatuses_PreservesPendingApproval(t *testing.T) {
+	team := minimalTeam("sync-preserve")
+	team.Status.Teammates = []claudev1alpha1.TeammateStatus{
+		{Name: "worker", PendingApproval: "spawn-worker"},
+	}
+	r := newReconciler(team) // no pods
+	team = fetch(t, r, "sync-preserve")
+
+	r.syncPodStatuses(context.Background(), team)
+
+	require.Len(t, team.Status.Teammates, 1)
+	assert.Equal(t, "spawn-worker", team.Status.Teammates[0].PendingApproval,
+		"PendingApproval must survive a sync cycle")
+	assert.Equal(t, "Waiting", team.Status.Teammates[0].Phase,
+		"pod-missing teammate must report Waiting even when other fields are preserved")
+}
+
+// --- Event emission on phase transitions ---
+
+// TestReconcilePending_EmitsInitializingEvent verifies the Pending → Initializing
+// transition emits a Normal event so `kubectl describe` surfaces it.
+func TestReconcilePending_EmitsInitializingEvent(t *testing.T) {
+	team := withWorkspace(minimalTeam("evt-init"))
+	r := newReconciler(team)
+	recorder := record.NewFakeRecorder(8)
+	r.Recorder = recorder
+	ctx := context.Background()
+
+	_, err := r.reconcilePending(ctx, fetch(t, r, "evt-init"))
+	require.NoError(t, err)
+
+	events := drainFakeRecorder(recorder)
+	require.NotEmpty(t, events, "expected at least one event on transition")
+	found := false
+	for _, e := range events {
+		if strings.Contains(e, "Normal") && strings.Contains(e, "Initializing") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected a Normal Initializing event, got: %v", events)
+}
+
+// TestReconcileRunning_EmitsCompletedEvent verifies the Running → Completed
+// transition emits a Normal Completed event.
+func TestReconcileRunning_EmitsCompletedEvent(t *testing.T) {
+	team := minimalTeam("evt-done")
+	startTime := metav1.NewTime(time.Now().Add(-1 * time.Minute))
+	team.Status.Phase = "Running"
+	team.Status.StartedAt = &startTime
+	leadPod := succeededPod("evt-done-lead", "default", "evt-done")
+	workerPod := succeededPod("evt-done-worker", "default", "evt-done")
+	r := newReconciler(team, leadPod, workerPod)
+	recorder := record.NewFakeRecorder(8)
+	r.Recorder = recorder
+	ctx := context.Background()
+
+	_, err := r.reconcileRunning(ctx, fetch(t, r, "evt-done"))
+	require.NoError(t, err)
+
+	events := drainFakeRecorder(recorder)
+	found := false
+	for _, e := range events {
+		if strings.Contains(e, "Normal") && strings.Contains(e, "Completed") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected a Normal Completed event, got: %v", events)
+}
+
+// TestReconcileRunning_EmitsWarningOnAgentFailure verifies a failed teammate
+// pod triggers a Warning AgentFailed event.
+func TestReconcileRunning_EmitsWarningOnAgentFailure(t *testing.T) {
+	team := minimalTeam("evt-fail")
+	startTime := metav1.NewTime(time.Now().Add(-1 * time.Minute))
+	team.Status.Phase = "Running"
+	team.Status.StartedAt = &startTime
+	leadPod := runningPod("evt-fail-lead", "default", "evt-fail")
+	workerPod := failedPod("evt-fail-worker", "default", "evt-fail")
+	r := newReconciler(team, leadPod, workerPod)
+	recorder := record.NewFakeRecorder(8)
+	r.Recorder = recorder
+	ctx := context.Background()
+
+	_, err := r.reconcileRunning(ctx, fetch(t, r, "evt-fail"))
+	require.NoError(t, err)
+
+	events := drainFakeRecorder(recorder)
+	found := false
+	for _, e := range events {
+		if strings.Contains(e, "Warning") && strings.Contains(e, "AgentFailed") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected a Warning AgentFailed event, got: %v", events)
+}
+
+// TestRecordEvent_NilRecorderIsNoop verifies recordEvent is safe with a nil
+// Recorder — unit tests construct reconcilers directly without
+// SetupWithManager, so recordEvent calls from production code paths must not
+// panic in that setup.
+func TestRecordEvent_NilRecorderIsNoop(t *testing.T) {
+	r := &AgentTeamReconciler{}
+	team := minimalTeam("nil-rec")
+	assert.NotPanics(t, func() {
+		r.recordEvent(team, corev1.EventTypeNormal, "Test", "no panic with nil recorder")
+	})
 }


### PR DESCRIPTION
## Summary
Three coordinated changes to turn `kubectl get/describe agentteam` into a useful demo surface. Closes #7.

### 1. New `status.ready` field + fixed print column
The existing `Teammates` column was mislabeled — it pointed at `status.tasks.total` (task count, not teammate count). Replaced with a Deployment-style `Ready` column (e.g. `3/5`) populated by `syncPodStatuses` from the count of teammates in `Running` or `Completed` phase.

Before: `PHASE | TEAMMATES | TASKS DONE | COST | AGE` (Teammates showed task total — misleading)
After:  `PHASE | READY | TASKS DONE | COST | AGE`

### 2. Extended `syncPodStatuses`
Every teammate in the spec now gets a `TeammateStatus` entry even before its pod is scheduled — they surface as `Phase="Waiting"` so `kubectl describe` shows the full roster during startup (dependsOn, approval gates, first-reconcile). Non-pod fields (`TasksCompleted`, `TasksClaimed`, `PendingApproval`) are preserved across resyncs. Transient API errors leave the prior phase untouched rather than clobbering it with `Waiting`.

### 3. EventRecorder wired at phase transitions
All 8 phase transitions now emit Events — `Normal` for good transitions, `Warning` for terminal-bad ones:

| From → To | Reason | Event Type |
|-----------|--------|------------|
| Pending → Initializing | `Initializing` | Normal |
| Initializing → Running | `Running` | Normal |
| Initializing → TimedOut | `TimedOut` | Warning |
| Initializing → Failed (init job) | `InitJobFailed` | Warning |
| Running → TimedOut | `TimedOut` | Warning |
| Running → BudgetExceeded | `BudgetExceeded` | Warning |
| Running → Failed (agent) | `AgentFailed` | Warning |
| Running → Completed | `Completed` | Normal |

The `Events:` section of `kubectl describe` becomes a usable lifecycle trail for demos and debugging. RBAC is extended with `events: create,patch` (auto-generated via the `+kubebuilder:rbac` marker).

### Out of scope (deliberate)
`TasksCompleted` and `TasksClaimed` fields are not populated here — they require parsing the shared task list JSON from the PVC, which is v0.3.0 observability work. The code comments this deferral explicitly.

## Test plan
- [x] 4 new unit tests for the extended `syncPodStatuses` behavior
- [x] 3 new unit tests for event emission (Normal Initializing, Normal Completed, Warning AgentFailed)
- [x] 1 new unit test proving `recordEvent` is a no-op with a nil Recorder (so unit tests that don't invoke `SetupWithManager` still work)
- [x] Full suite still passes: `go test ./... -count=1`
- [x] `go vet ./...` clean
- [x] `make manifests generate` clean-tree
- [x] Manual review of the regenerated CRD shows `ready` field added and print columns updated correctly