### PR TITLE
test: add E2E suite against the real Anthropic API (#5)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,97 @@
+name: E2E Tests (Real Claude API)
+
+# Real-API E2E runs hit the Anthropic API and cost money per run. We gate them
+# tightly:
+#   * Only on pushes to main (post-merge, final verification before a release)
+#   * Only when the ANTHROPIC_API_KEY secret is configured
+#   * workflow_dispatch available for ad-hoc manual runs by maintainers
+#
+# Rationale: this is the only test that proves the full AgentTeam coordination
+# story works with real Claude Code. Worth running, but not on every PR.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # Preflight checks the secret exists. Without this, a fork or maintainer
+  # without the secret configured would get a loud, late failure from
+  # test BeforeSuite instead of a clean skip.
+  preflight:
+    name: Preflight (secret check)
+    runs-on: ubuntu-latest
+    outputs:
+      has_key: ${{ steps.check.outputs.has_key }}
+    steps:
+      - id: check
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "$ANTHROPIC_API_KEY" ]; then
+            echo "has_key=true" >> "$GITHUB_OUTPUT"
+            echo "ANTHROPIC_API_KEY is configured — E2E job will run."
+          else
+            echo "has_key=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::ANTHROPIC_API_KEY not configured — E2E job will be skipped."
+          fi
+
+  e2e:
+    name: E2E (Kind + real runner)
+    needs: preflight
+    if: needs.preflight.outputs.has_key == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # ── Kind ──────────────────────────────────────────────────────────────
+      - name: Install Kind
+        run: go install sigs.k8s.io/kind@latest
+
+      # ── Build images + bring up cluster via the shared setup script ───────
+      # hack/e2e-setup.sh does all the image-building, CRD-installing, operator-
+      # deploying work. We re-use it here so the CI path and the local path
+      # stay in lock-step.
+      - name: Bring up E2E cluster
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          KIND_CLUSTER_NAME: claude-teams-e2e
+        run: make e2e-up
+
+      # ── Run the suite ──────────────────────────────────────────────────────
+      - name: Run E2E tests
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: make test-e2e
+
+      # ── Debug on failure ───────────────────────────────────────────────────
+      - name: Collect operator logs on failure
+        if: failure()
+        run: |
+          echo "=== Operator logs ==="
+          kubectl logs -n claude-teams-system \
+            deployment/controller-manager --tail=200 || true
+
+          echo "=== AgentTeams ==="
+          kubectl get agentteams -A -o wide || true
+
+          echo "=== Pods in test namespaces ==="
+          kubectl get pods -A --selector='claude.amcheste.io/team' -o wide || true
+
+          echo "=== Recent events ==="
+          kubectl get events -A --sort-by='.lastTimestamp' | tail -50 || true
+
+      - name: Delete Kind cluster
+        if: always()
+        env:
+          KIND_CLUSTER_NAME: claude-teams-e2e
+        run: make e2e-down

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,18 @@ acceptance-down: ## Tear down Kind acceptance cluster
 mailbox-smoke-test: ## Validate mailbox file exchange on shared PVC (requires acceptance-up or any cluster with an 'nfs' StorageClass)
 	bash hack/mailbox-smoke-test.sh
 
+.PHONY: test-e2e
+test-e2e: ## Run E2E tests against the real Anthropic API (requires e2e-up and ANTHROPIC_API_KEY)
+	go test ./test/e2e/... -tags=e2e -v -count=1 -timeout=20m
+
+.PHONY: e2e-up
+e2e-up: ## Create Kind cluster + build real runner image + deploy operator for E2E (requires ANTHROPIC_API_KEY)
+	PATH="/opt/homebrew/bin:/usr/local/bin:$(PATH)" bash hack/e2e-setup.sh
+
+.PHONY: e2e-down
+e2e-down: ## Tear down Kind E2E cluster
+	kind delete cluster --name $${KIND_CLUSTER_NAME:-claude-teams-e2e}
+
 .PHONY: envtest
 envtest: ## Install setup-envtest
 	@test -f $(SETUP_ENVTEST) || go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest

--- a/hack/e2e-setup.sh
+++ b/hack/e2e-setup.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# hack/e2e-setup.sh
+#
+# Creates a Kind cluster, builds the operator image and the claude-code-runner
+# image, loads both into Kind, installs CRDs, and deploys the operator with NO
+# agent-image override — so agent pods start the real Claude Code runner and
+# call the live Anthropic API.
+#
+# The ANTHROPIC_API_KEY env var is required — the E2E test suite reads it to
+# populate per-test Secrets that the AgentTeam references.
+#
+# Usage:
+#   export ANTHROPIC_API_KEY=sk-ant-...
+#   bash hack/e2e-setup.sh
+#
+# Requires: kind, kubectl, docker, go (for make manifests)
+
+set -euo pipefail
+
+# Extend PATH to pick up Docker Desktop and Homebrew binaries.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/Applications/Docker.app/Contents/Resources/bin:${PATH}"
+
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+  echo "ERROR: ANTHROPIC_API_KEY is not set — the E2E suite hits the real API."
+  echo "       export ANTHROPIC_API_KEY=sk-ant-... and re-run."
+  exit 1
+fi
+
+CLUSTER_NAME="${KIND_CLUSTER_NAME:-claude-teams-e2e}"
+OPERATOR_IMG="${OPERATOR_IMG:-ghcr.io/amcheste/claude-teams-operator:e2e}"
+RUNNER_IMG="${RUNNER_IMG:-ghcr.io/amcheste/claude-code-runner:e2e}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+log() { echo "==> $*"; }
+
+log "Building operator image ${OPERATOR_IMG}"
+docker build -t "${OPERATOR_IMG}" -f "${REPO_ROOT}/docker/Dockerfile.operator" "${REPO_ROOT}"
+
+log "Building claude-code-runner image ${RUNNER_IMG}"
+docker build -t "${RUNNER_IMG}" -f "${REPO_ROOT}/docker/Dockerfile.claude-code" "${REPO_ROOT}"
+
+log "Creating Kind cluster '${CLUSTER_NAME}' (skips if already exists)"
+if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+  log "Cluster '${CLUSTER_NAME}' already exists — reusing"
+else
+  kind create cluster --name "${CLUSTER_NAME}" --wait 120s
+fi
+
+log "Loading images into Kind"
+kind load docker-image "${OPERATOR_IMG}" --name "${CLUSTER_NAME}"
+kind load docker-image "${RUNNER_IMG}" --name "${CLUSTER_NAME}"
+
+# Pre-pull busybox for the test's verifier pod so specs don't pause on image pull.
+log "Pre-pulling busybox for verifier pods"
+docker pull busybox:latest
+kind load docker-image busybox:latest --name "${CLUSTER_NAME}"
+
+log "Generating CRD manifests"
+cd "${REPO_ROOT}" && make manifests --no-print-directory
+
+log "Installing CRDs"
+kubectl apply -f "${REPO_ROOT}/config/crd/bases/"
+
+# Same alias pattern as acceptance-setup.sh: the operator's default PVCs request
+# StorageClass 'nfs', and a single-node Kind doesn't have one. Alias 'nfs' to
+# local-path-provisioner so PVCs bind.
+log "Creating 'nfs' StorageClass alias for Kind (backed by local-path-provisioner)"
+kubectl apply -f - <<'YAML'
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nfs
+provisioner: rancher.io/local-path
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+YAML
+
+log "Deploying RBAC"
+kubectl apply -f "${REPO_ROOT}/config/rbac/"
+
+log "Creating operator namespace"
+kubectl apply -f "${REPO_ROOT}/config/manager/namespace.yaml"
+
+log "Deploying operator (E2E mode: real runner image, no agent-command override)"
+kubectl apply -f "${REPO_ROOT}/config/manager/manager.yaml"
+kubectl set image deployment/controller-manager \
+  manager="${OPERATOR_IMG}" \
+  -n claude-teams-system
+
+# Point the operator at the real runner image we just built. Because Kind is
+# single-node we still need --pvc-access-mode=ReadWriteOnce so the default RWX
+# request doesn't block PVC binding on local-path.
+kubectl patch deployment controller-manager \
+  -n claude-teams-system \
+  --type=json \
+  -p='[
+    {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--agent-image='"${RUNNER_IMG}"'"},
+    {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--pvc-access-mode=ReadWriteOnce"}
+  ]'
+
+log "Waiting for operator to be ready"
+kubectl rollout status deployment/controller-manager \
+  -n claude-teams-system \
+  --timeout=120s
+
+log ""
+log "E2E environment is ready."
+log "  Cluster   : ${CLUSTER_NAME}"
+log "  Operator  : ${OPERATOR_IMG}"
+log "  Runner    : ${RUNNER_IMG}"
+log ""
+log "Run E2E tests (reads ANTHROPIC_API_KEY from env):"
+log "  make test-e2e"
+log ""
+log "Tear down when done:"
+log "  make e2e-down"

--- a/test/e2e/claude_api_test.go
+++ b/test/e2e/claude_api_test.go
@@ -1,0 +1,211 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"bytes"
+	"io"
+	"regexp"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	claudev1alpha1 "github.com/amcheste/claude-teams-operator/api/v1alpha1"
+)
+
+// Real Claude Code runs against the live API. One run per commit is deliberate —
+// see package doc for rationale.
+var _ = Describe("Real Claude API end-to-end", func() {
+
+	Describe("Cowork mode — single teammate writes a file", func() {
+		var (
+			namespace string
+			team      *claudev1alpha1.AgentTeam
+		)
+
+		BeforeEach(func() {
+			namespace = testNS()
+			createAPIKeySecret("anthropic-key", namespace)
+
+			budget := "0.10"
+			team = &claudev1alpha1.AgentTeam{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "e2e-hello-world",
+					Namespace: namespace,
+				},
+				Spec: claudev1alpha1.AgentTeamSpec{
+					Auth: claudev1alpha1.AuthSpec{APIKeySecret: "anthropic-key"},
+					Lead: claudev1alpha1.LeadSpec{
+						Model: "haiku",
+						// The lead's only job is to confirm readiness and exit.
+						// We're testing the coordination plumbing, not multi-turn
+						// delegation — that's a v0.3.0 concern.
+						Prompt: "Reply with the single word 'ready' and stop.",
+						// auto-accept lets the teammate use the Write tool without
+						// interactive approval — required for any non-trivial task
+						// inside a pod.
+						PermissionMode: "auto-accept",
+					},
+					Teammates: []claudev1alpha1.TeammateSpec{
+						{
+							Name:  "writer",
+							Model: "haiku",
+							// The prompt is deliberately directive: exact file path,
+							// exact expected content shape, single-turn action. This
+							// minimizes both cost and flakiness.
+							//
+							// Note: teammate pods always run with auto-accept; there
+							// is no PermissionMode field on TeammateSpec by design.
+							Prompt: "Use the Write tool to create the file " +
+								"/workspace/output/hello.go with this exact content " +
+								"and nothing else:\n\n" +
+								"package main\n\n" +
+								"import \"fmt\"\n\n" +
+								"func main() {\n" +
+								"\tfmt.Println(\"hello, world\")\n" +
+								"}\n\n" +
+								"After the file is written, reply 'done' and stop.",
+						},
+					},
+					Workspace: &claudev1alpha1.WorkspaceSpec{
+						Output: &claudev1alpha1.WorkspaceOutputSpec{
+							StorageClass: "nfs",
+							Size:         "100Mi",
+						},
+					},
+					Lifecycle: &claudev1alpha1.LifecycleSpec{
+						// Operator-level timeout: bounds worst-case pod lifetime if
+						// Claude gets stuck. BudgetLimit bounds worst-case spend.
+						Timeout:     "5m",
+						BudgetLimit: &budget,
+						OnComplete:  "notify",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, team)).To(Succeed())
+		})
+
+		It("reaches Completed phase and writes hello.go to the output PVC", func() {
+			// Step 1: team runs to completion.
+			Eventually(func(g Gomega) {
+				var got claudev1alpha1.AgentTeam
+				g.Expect(k8sClient.Get(ctx, nn(team.Name, namespace), &got)).To(Succeed())
+				g.Expect(got.Status.Phase).To(Equal("Completed"),
+					"team is still %s; events: see kubectl describe", got.Status.Phase)
+			}).Should(Succeed(), "team never reached Completed")
+
+			// Step 2: status.ready reflects the single running+completed teammate.
+			// This exercises the field added for issue #7.
+			var final claudev1alpha1.AgentTeam
+			Expect(k8sClient.Get(ctx, nn(team.Name, namespace), &final)).To(Succeed())
+			Expect(final.Status.Ready).To(Equal("1/1"))
+
+			// Step 3: the file survives on the output PVC. Team pods have been
+			// deleted by reconcileTerminal, so we spin up a verifier pod that
+			// mounts the PVC and cats the file.
+			content := readFileFromOutputPVC(namespace, team.Name+"-output", "/out/hello.go")
+			Expect(content).To(MatchRegexp(`package\s+main`))
+			Expect(content).To(MatchRegexp(`func\s+main\s*\(\s*\)`))
+			Expect(content).To(ContainSubstring("hello, world"))
+		})
+	})
+})
+
+// readFileFromOutputPVC creates a short-lived pod that mounts the given PVC
+// at /out and prints the requested file to stdout. Returns the captured stdout.
+//
+// We use a pod (not a Job) so we can stream logs even if the pod is in Pending
+// briefly — logs API handles both cases. Mount is read-only because the team
+// has already terminated and we don't want to accidentally alter state.
+func readFileFromOutputPVC(namespace, pvcName, filePath string) string {
+	GinkgoHelper()
+
+	podName := "verify-output-" + randSuffix()
+	verifier := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{{
+				Name:    "cat",
+				Image:   "busybox:latest",
+				Command: []string{"sh", "-c", "cat " + filePath},
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "out",
+					MountPath: "/out",
+					ReadOnly:  true,
+				}},
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "out",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
+						ReadOnly:  true,
+					},
+				},
+			}},
+		},
+	}
+	Expect(k8sClient.Create(ctx, verifier)).To(Succeed())
+	DeferCleanup(func() {
+		_ = k8sClient.Delete(ctx, verifier)
+	})
+
+	// Wait for the verifier to finish (Succeeded or Failed).
+	Eventually(func(g Gomega) {
+		var p corev1.Pod
+		g.Expect(k8sClient.Get(ctx, nn(podName, namespace), &p)).To(Succeed())
+		g.Expect(p.Status.Phase).To(Or(
+			Equal(corev1.PodSucceeded),
+			Equal(corev1.PodFailed),
+		))
+	}).WithTimeout(3 * time.Minute).WithPolling(3 * time.Second).
+		Should(Succeed(), "verifier pod never terminated")
+
+	// Read logs. controller-runtime's typed client doesn't expose log
+	// streaming, so drop down to client-go.
+	cfg, err := ctrl.GetConfig()
+	Expect(err).NotTo(HaveOccurred())
+	cs, err := kubernetes.NewForConfig(cfg)
+	Expect(err).NotTo(HaveOccurred())
+
+	req := cs.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{})
+	stream, err := req.Stream(ctx)
+	Expect(err).NotTo(HaveOccurred())
+	defer stream.Close()
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, stream)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Verify the pod actually succeeded — if the file was missing, busybox
+	// cat exits non-zero and we want the test to fail with a clear message.
+	var p corev1.Pod
+	Expect(k8sClient.Get(ctx, nn(podName, namespace), &p)).To(Succeed())
+	Expect(p.Status.Phase).To(Equal(corev1.PodSucceeded),
+		"verifier pod failed — file %q likely does not exist on PVC %q. Pod logs:\n%s",
+		filePath, pvcName, buf.String())
+
+	return buf.String()
+}
+
+// randSuffix returns a short lowercase string suitable for appending to resource
+// names within a test namespace. We avoid importing uuid for such a small need.
+var randSuffixRegex = regexp.MustCompile(`[^a-z0-9]`)
+
+func randSuffix() string {
+	// Ginkgo's GenerateName-like helper isn't exported; use timestamp ns.
+	t := time.Now().UnixNano()
+	s := make([]byte, 0, 8)
+	for i := 0; i < 8; i++ {
+		c := byte('a' + t%26)
+		s = append(s, c)
+		t /= 26
+	}
+	return randSuffixRegex.ReplaceAllString(string(s), "x")
+}

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1,0 +1,137 @@
+//go:build e2e
+
+// Package e2e_test contains end-to-end tests that exercise the operator against
+// the live Anthropic API using the real claude-code-runner image. Unlike the
+// acceptance suite (which uses busybox and never hits the API), these tests
+// verify that the full AgentTeam coordination story — mailbox/task PVCs,
+// agent pod startup, real Claude Code execution — works against production
+// infrastructure.
+//
+// Prerequisites:
+//
+//	export ANTHROPIC_API_KEY=sk-ant-...
+//	make e2e-up      # create Kind cluster with real runner image
+//	make test-e2e    # run this suite
+//	make e2e-down    # tear down cluster
+//
+// The operator must be deployed WITHOUT --agent-image=busybox, so agent pods
+// start the real Claude Code runner. The ANTHROPIC_API_KEY env var is required
+// both for deploying the cluster (baked into a K8s Secret) and for the tests
+// themselves, which re-use it to populate per-test Secrets.
+//
+// This suite is deliberately small (one test by default). Each run costs real
+// API credits, so the goal is minimum viable verification, not exhaustive
+// coverage. The bounded prompt + budgetLimit caps worst-case spend per run.
+package e2e_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	claudev1alpha1 "github.com/amcheste/claude-teams-operator/api/v1alpha1"
+)
+
+var (
+	k8sClient client.Client
+	ctx       context.Context
+	cancel    context.CancelFunc
+	apiKey    string
+)
+
+const (
+	operatorNamespace  = "claude-teams-system"
+	operatorDeployment = "controller-manager"
+)
+
+// TestE2E is the Ginkgo entry point.
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AgentTeam E2E Suite (real Claude API)")
+}
+
+var _ = BeforeSuite(func() {
+	ctx, cancel = context.WithCancel(context.Background())
+
+	apiKey = os.Getenv("ANTHROPIC_API_KEY")
+	Expect(apiKey).NotTo(BeEmpty(),
+		"ANTHROPIC_API_KEY must be set — this suite hits the real Anthropic API")
+
+	cfg, err := ctrl.GetConfig()
+	Expect(err).NotTo(HaveOccurred(), "could not get cluster config — is KUBECONFIG set?")
+
+	scheme := runtime.NewScheme()
+	Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+	Expect(claudev1alpha1.AddToScheme(scheme)).To(Succeed())
+	Expect(appsv1.AddToScheme(scheme)).To(Succeed())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Wait for the operator deployment before running the test. The operator
+	// must be deployed by make e2e-up before this point; we only verify it
+	// came up cleanly.
+	GinkgoWriter.Println("waiting for operator to be ready…")
+	Eventually(func(g Gomega) {
+		var d appsv1.Deployment
+		g.Expect(k8sClient.Get(ctx,
+			types.NamespacedName{Name: operatorDeployment, Namespace: operatorNamespace}, &d,
+		)).To(Succeed())
+		g.Expect(d.Status.ReadyReplicas).To(BeNumerically(">=", 1))
+	}).WithTimeout(2 * time.Minute).WithPolling(3 * time.Second).Should(Succeed(),
+		"operator deployment never became ready")
+	GinkgoWriter.Println("operator is ready")
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+})
+
+func init() {
+	// Real Claude Code runs take longer than the busybox acceptance suite.
+	// 10 minutes accommodates image pull + pod scheduling + a few retries,
+	// while the operator's own Lifecycle.Timeout caps the per-team budget.
+	SetDefaultEventuallyTimeout(10 * time.Minute)
+	SetDefaultEventuallyPollingInterval(5 * time.Second)
+}
+
+// --- Shared helpers ---
+
+// testNS creates a fresh namespace and registers DeferCleanup to delete it.
+func testNS() string {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "e2e-"},
+	}
+	Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+	DeferCleanup(func() {
+		_ = k8sClient.Delete(ctx, ns)
+	})
+	return ns.Name
+}
+
+// nn is a shortcut for types.NamespacedName.
+func nn(name, namespace string) types.NamespacedName {
+	return types.NamespacedName{Name: name, Namespace: namespace}
+}
+
+// createAPIKeySecret writes the real ANTHROPIC_API_KEY into a Secret the team can reference.
+func createAPIKeySecret(name, namespace string) {
+	GinkgoHelper()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		StringData: map[string]string{"ANTHROPIC_API_KEY": apiKey},
+	}
+	Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+}


### PR DESCRIPTION
## Summary

Adds a build-tagged (`e2e`) acceptance suite that runs with the real `claude-code-runner` image against a live Anthropic API key. Closes the gap between the busybox acceptance tests and a genuine end-to-end run of the Agent Teams coordination protocol — unblocking the KUBECON.md demo milestone "A real coding task runs end-to-end in Kind".

## What's in the test

- **Cowork-mode team** with a single haiku-model teammate whose only job is to write `/workspace/output/hello.go` (a minimal Go `main` printing `hello, world`) and exit.
- **Verifier pod** mounts the team's output PVC read-only after the team reaches `Completed`, cats the file, and the test asserts the contents look right (`package main`, `func main()`, `hello, world`).
- **status.ready check** confirms the field added in #7 is populated correctly (`1/1`) on the real run.

## Bounded cost

- `Lifecycle.Timeout: "5m"` — operator kills the team if the prompt stalls.
- `Lifecycle.BudgetLimit: "0.10"` — operator marks `BudgetExceeded` long before a runaway run.
- Both lead and teammate use `haiku` — cheapest model.

## CI gating

- New workflow `.github/workflows/e2e.yml` runs **only on pushes to `main`** and on `workflow_dispatch`.
- A preflight job checks `secrets.ANTHROPIC_API_KEY` is configured; if not, the real E2E job is skipped with a warning instead of failing late.
- Re-uses `make e2e-up` / `make test-e2e` / `make e2e-down` so the CI path and the local path stay identical.

## Files

| File | Purpose |
|------|---------|
| `test/e2e/suite_test.go` | Ginkgo bootstrap, `//go:build e2e` |
| `test/e2e/claude_api_test.go` | The single end-to-end spec |
| `hack/e2e-setup.sh` | Kind cluster + real runner image + operator |
| `.github/workflows/e2e.yml` | `main`-only workflow, secret-gated |
| `Makefile` | New targets: `test-e2e`, `e2e-up`, `e2e-down` |

## Scope notes

- **Cowork mode, not coding mode.** Avoids the extra surface area of git worktrees for this first real-API test. Coding-mode E2E can land in v0.3.0 once we have metrics to observe it.
- **Single teammate, not multi-agent.** One is the minimum to exercise the pod → PVC → verifier chain end-to-end. Multi-agent coordination in real API is a separate test we'll want once we have observability.
- **Per-run cost is real money.** `main`-only gating is intentional — this is a release-time smoke, not a per-PR check.

## Test plan

- [x] `go vet -tags=e2e ./test/e2e/...` — clean
- [x] `go test -tags=e2e -run=NonExistentTestName ./test/e2e/...` — compiles
- [x] `go test ./...` — existing unit tests still pass
- [ ] Manual: `export ANTHROPIC_API_KEY=... && make e2e-up && make test-e2e && make e2e-down` on a local Kind
- [ ] CI: first `main` push triggers the new workflow and passes (or skips cleanly if the secret isn't yet configured)

Closes #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)