### PR TITLE
ci: publish helm chart and install.yaml to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,11 +99,53 @@ jobs:
           cosign sign --yes \
             ghcr.io/amcheste/claude-code-runner@${{ steps.build-runner.outputs.digest }}
 
+  # ── Publish Helm chart to GHCR as OCI ─────────────────────────────────────
+  chart:
+    name: Publish Helm Chart
+    runs-on: ubuntu-latest
+    needs: validate
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        with:
+          version: v3.16.2
+
+      - name: Pin chart image tags to release version
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          # values.yaml ships tag: latest for both operator and runner. At
+          # release time we pin both to the release tag so `helm install
+          # --version=vX.Y.Z` pulls matching images by default.
+          sed -i "s|tag: latest|tag: ${TAG}|g" charts/claude-teams-operator/values.yaml
+
+      - name: Log in to GitHub Container Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Package and push chart
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          # Helm chart versions must be SemVer without a leading 'v'.
+          VERSION_NUM="${TAG#v}"
+          helm package charts/claude-teams-operator \
+            --version "${VERSION_NUM}" \
+            --app-version "${VERSION_NUM}"
+          helm push "claude-teams-operator-${VERSION_NUM}.tgz" \
+            oci://ghcr.io/amcheste/charts
+
   # ── Create GitHub Release ─────────────────────────────────────────────────
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [validate, images]
+    needs: [validate, images, chart]
     permissions:
       contents: write
     steps:
@@ -111,7 +153,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect pre-release
+      - name: Detect pre-release and compute chart version
         id: prerelease
         run: |
           if [[ "${GITHUB_REF_NAME}" =~ v[0-9]+\.[0-9]+\.[0-9]+-[a-zA-Z] ]]; then
@@ -121,19 +163,28 @@ jobs:
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
             echo "Detected stable tag: ${GITHUB_REF_NAME}"
           fi
+          # Chart versions are SemVer without the leading 'v'. Expose both so
+          # the release body can reference the right form for helm install.
+          echo "version_num=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate install.yaml
+        env:
+          TAG: ${{ github.ref_name }}
+        run: bash hack/generate-install-yaml.sh > install.yaml
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           prerelease: ${{ steps.prerelease.outputs.is_prerelease == 'true' }}
           generate_release_notes: true
+          files: install.yaml
           body: |
             ## Install
 
             ```bash
             # Helm (recommended)
             helm install claude-teams-operator oci://ghcr.io/amcheste/charts/claude-teams-operator \
-              --version ${{ github.ref_name }}
+              --version ${{ steps.prerelease.outputs.version_num }}
 
             # Raw manifests
             kubectl apply -f https://github.com/amcheste/claude-teams-operator/releases/download/${{ github.ref_name }}/install.yaml

--- a/hack/generate-install-yaml.sh
+++ b/hack/generate-install-yaml.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# hack/generate-install-yaml.sh
+#
+# Produces a single `install.yaml` that `kubectl apply -f` can consume end-to-
+# end to deploy the operator. Bundles:
+#   1. The claude-teams-system namespace
+#   2. All CRDs (AgentTeam, AgentTeamTemplate, AgentTeamRun)
+#   3. RBAC (ClusterRole + ClusterRoleBinding)
+#   4. The operator Deployment, with image + --agent-image pinned to $TAG
+#
+# Used by .github/workflows/release.yml to attach install.yaml to each GitHub
+# Release so users can `kubectl apply -f <release-url>/install.yaml` without
+# needing Helm.
+#
+# Usage:
+#   TAG=v0.2.0 hack/generate-install-yaml.sh > install.yaml
+#
+# TAG is required — unpinned manifests would pull :latest and defeat the
+# purpose of a release artifact.
+
+set -euo pipefail
+
+if [[ -z "${TAG:-}" ]]; then
+  echo "ERROR: TAG must be set (e.g. TAG=v0.2.0)" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cat "${REPO_ROOT}/config/manager/namespace.yaml"
+echo "---"
+
+for f in "${REPO_ROOT}"/config/crd/bases/*.yaml; do
+  cat "$f"
+  echo "---"
+done
+
+for f in "${REPO_ROOT}"/config/rbac/*.yaml; do
+  cat "$f"
+  echo "---"
+done
+
+# Pin the operator image to the release tag, and add --agent-image so agent
+# pods use the matching runner version (the controller's hardcoded default is
+# :latest, which would drift from the release). awk keeps this portable across
+# GNU/BSD sed differences — this script runs in both Ubuntu CI and local dev.
+awk -v tag="${TAG}" '
+  /ghcr.io\/amcheste\/claude-teams-operator:latest/ {
+    sub(/:latest/, ":" tag)
+  }
+  /- --metrics-bind-address=:8080/ {
+    print
+    match($0, /^[[:space:]]*/)
+    indent = substr($0, 1, RLENGTH)
+    print indent "- --agent-image=ghcr.io/amcheste/claude-code-runner:" tag
+    next
+  }
+  { print }
+' "${REPO_ROOT}/config/manager/manager.yaml"


### PR DESCRIPTION
## Summary

The release workflow previously pushed only the operator + runner container images. The release body advertised two more install paths — `helm install oci://ghcr.io/amcheste/charts/claude-teams-operator` and `kubectl apply -f .../install.yaml` — but neither artifact was actually produced. This PR closes that gap so tagging `v0.2.0` gives users working install instructions.

## Changes

- **New `chart` job in `release.yml`** — pins `charts/claude-teams-operator/values.yaml` default image tags to the release tag, `helm package` with `--version=${TAG#v}` (chart SemVer rejects the leading `v`), and `helm push` to `oci://ghcr.io/amcheste/charts`.
- **`hack/generate-install-yaml.sh`** — concatenates namespace + 3 CRDs + RBAC + manager manifests, pinning both the operator image and injecting `--agent-image=ghcr.io/amcheste/claude-code-runner:${TAG}` (controller's hardcoded default is `:latest`, which would otherwise drift).
- **`release` job** — now depends on `chart`, runs the generator, and attaches `install.yaml` via `softprops/action-gh-release`'s `files:` input.
- **Release body** — uses a new `steps.prerelease.outputs.version_num` (tag without leading `v`) in the helm snippet so `helm install --version=0.2.0` resolves correctly against the OCI chart.

## Test plan

- [x] `hack/generate-install-yaml.sh` locally: 1847 lines, all 8 resources (Namespace, 3 CRDs, ClusterRole, ClusterRoleBinding, ServiceAccount, Deployment) apply cleanly with `kubectl apply --dry-run=client`; operator image + `--agent-image` correctly pinned to `v0.2.0`.
- [x] `shellcheck hack/generate-install-yaml.sh` — clean.
- [x] `actionlint .github/workflows/release.yml` — clean.
- [x] `azure/setup-helm@v4` SHA verified against `gh api .../git/refs/tags/v4` → annotated tag dereferences to `1a275c3…`.
- [ ] End-to-end verified on the next tag push (`v0.2.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)