### PR TITLE
fix(chart): ship CRDs with the Helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,12 @@ help: ## Display this help
 .PHONY: manifests
 manifests: controller-gen ## Generate CRD manifests
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	# Mirror CRDs into the Helm chart's crds/ dir. Helm installs anything in
+	# crds/ on `helm install` (but not on upgrade, by design). Without this
+	# `helm install` deploys the operator but leaves it crash-looping waiting
+	# for CRDs that were never applied.
+	@mkdir -p charts/claude-teams-operator/crds
+	@cp -f config/crd/bases/*.yaml charts/claude-teams-operator/crds/
 
 .PHONY: generate
 generate: controller-gen ## Generate deepcopy methods

--- a/charts/claude-teams-operator/crds/claude.amcheste.io_agentteamruns.yaml
+++ b/charts/claude-teams-operator/crds/claude.amcheste.io_agentteamruns.yaml
@@ -1,0 +1,543 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  name: agentteamruns.claude.amcheste.io
+spec:
+  group: claude.amcheste.io
+  names:
+    kind: AgentTeamRun
+    listKind: AgentTeamRunList
+    plural: agentteamruns
+    singular: agentteamrun
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.templateRef.name
+      name: Template
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AgentTeamRun is an instance of an AgentTeamTemplate applied to
+          a specific repository.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AgentTeamRunSpec defines an instance of a template applied
+              to a specific repo.
+            properties:
+              auth:
+                description: Auth configures API authentication for this run.
+                properties:
+                  apiKeySecret:
+                    description: APIKeySecret references a Secret containing ANTHROPIC_API_KEY.
+                    type: string
+                  oauthSecret:
+                    description: OAuthSecret references a Secret containing OAuth
+                      tokens for subscription auth.
+                    type: string
+                type: object
+              lead:
+                description: Lead configures the team lead for this run.
+                properties:
+                  mcpServers:
+                    description: MCPServers configures Model Context Protocol connections
+                      for the lead agent.
+                    items:
+                      description: MCPServerSpec configures a Model Context Protocol
+                        server for an agent.
+                      properties:
+                        credentialsSecret:
+                          description: CredentialsSecret references a Secret containing
+                            an 'apiKey' key for bearer auth.
+                          type: string
+                        name:
+                          description: Name identifies this MCP server in the agent's
+                            config.
+                          type: string
+                        url:
+                          description: URL is the MCP server endpoint.
+                          type: string
+                      required:
+                      - name
+                      - url
+                      type: object
+                    type: array
+                  model:
+                    default: opus
+                    description: Model to use for the team lead.
+                    enum:
+                    - opus
+                    - sonnet
+                    - haiku
+                    type: string
+                  permissionMode:
+                    default: auto-accept
+                    description: PermissionMode controls how the lead handles permission
+                      requests.
+                    enum:
+                    - auto-accept
+                    - plan
+                    - default
+                    type: string
+                  prompt:
+                    description: Prompt is the initial instruction for the team lead.
+                    type: string
+                  resources:
+                    description: Resources defines compute resources for the lead
+                      pod.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  skills:
+                    description: Skills to mount into .claude/skills/ for the lead
+                      agent.
+                    items:
+                      description: SkillSpec defines a Claude Code skill to mount
+                        into an agent pod.
+                      properties:
+                        name:
+                          description: Name is the skill directory name under .claude/skills/.
+                          type: string
+                        source:
+                          description: Source identifies where to load the skill from.
+                          properties:
+                            configMap:
+                              description: |-
+                                ConfigMap references a ConfigMap in the same namespace.
+                                Each key in the ConfigMap becomes a file in the skill directory.
+                              type: string
+                            oci:
+                              description: OCI is an OCI artifact reference containing
+                                the skill files (e.g. "ghcr.io/org/skills/web-research:v1").
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      - source
+                      type: object
+                    type: array
+                required:
+                - prompt
+                type: object
+              lifecycle:
+                description: Lifecycle overrides for this run.
+                properties:
+                  approvalGates:
+                    description: |-
+                      ApprovalGates pause execution before specified events until human approval is recorded.
+                      Grant approval by annotating the AgentTeam: kubectl annotate agentteam <name> approved.claude.amcheste.io/<event>=true
+                    items:
+                      description: |-
+                        ApprovalGateSpec pauses execution before a named event until human approval is recorded.
+                        Approval is granted by adding the annotation approved.claude.amcheste.io/{event}=true to the AgentTeam.
+                      properties:
+                        channel:
+                          default: none
+                          description: Channel is how the approval request notification
+                            is sent.
+                          enum:
+                          - webhook
+                          - none
+                          type: string
+                        event:
+                          description: Event is the gate identifier. Use "spawn-{teammate-name}"
+                            to gate spawning a specific teammate.
+                          type: string
+                        webhookUrl:
+                          description: WebhookURL to POST when this gate is triggered
+                            (used when channel is "webhook").
+                          type: string
+                      required:
+                      - event
+                      type: object
+                    type: array
+                  budgetLimit:
+                    description: BudgetLimit is the maximum API spend in USD before
+                      the team is terminated (e.g. "10.00").
+                    type: string
+                  onComplete:
+                    default: notify
+                    description: OnComplete determines what happens when the team
+                      finishes.
+                    enum:
+                    - create-pr
+                    - push-branch
+                    - notify
+                    - none
+                    type: string
+                  pullRequest:
+                    description: PullRequest configures PR creation when onComplete
+                      is "create-pr".
+                    properties:
+                      labels:
+                        description: Labels to apply to the PR.
+                        items:
+                          type: string
+                        type: array
+                      reviewers:
+                        description: Reviewers to request on the PR.
+                        items:
+                          type: string
+                        type: array
+                      targetBranch:
+                        default: main
+                        description: TargetBranch is the branch to open the PR against.
+                        type: string
+                      titleTemplate:
+                        description: |-
+                          TitleTemplate is a Go template for the PR title.
+                          Available variables: .TeamName, .Namespace
+                        type: string
+                    type: object
+                  timeout:
+                    default: 4h
+                    description: Timeout is the maximum duration the team can run
+                      (e.g. "4h", "30m").
+                    type: string
+                type: object
+              repository:
+                description: Repository configuration for this run (coding mode).
+                properties:
+                  branch:
+                    default: main
+                    description: Branch to clone and work from.
+                    type: string
+                  credentialsSecret:
+                    description: |-
+                      CredentialsSecret references a Secret containing git credentials.
+                      The secret should contain either 'ssh-privatekey' or 'token'.
+                    type: string
+                  url:
+                    description: URL is the git clone URL.
+                    type: string
+                  worktreeStrategy:
+                    default: per-teammate
+                    description: WorktreeStrategy determines how git worktrees are
+                      managed.
+                    enum:
+                    - per-teammate
+                    - shared
+                    type: string
+                required:
+                - url
+                type: object
+              templateRef:
+                description: TemplateRef references the AgentTeamTemplate to instantiate.
+                properties:
+                  name:
+                    description: Name of the AgentTeamTemplate in the same namespace.
+                    type: string
+                required:
+                - name
+                type: object
+              workspace:
+                description: Workspace configures inputs/outputs for this run (Cowork
+                  mode).
+                properties:
+                  inputs:
+                    description: Inputs are read-only volumes mounted into all agent
+                      pods.
+                    items:
+                      description: WorkspaceInputSpec defines a read-only input mounted
+                        into the agent pod.
+                      properties:
+                        configMap:
+                          description: ConfigMap references a ConfigMap to mount as
+                            a directory.
+                          type: string
+                        mountPath:
+                          description: MountPath is where to mount this input inside
+                            the container.
+                          type: string
+                        pvc:
+                          description: PVC references an existing PersistentVolumeClaim
+                            to mount read-only.
+                          type: string
+                      required:
+                      - mountPath
+                      type: object
+                    type: array
+                  output:
+                    description: Output configures the shared writable output volume.
+                    properties:
+                      mountPath:
+                        default: /workspace/output
+                        description: MountPath inside the container where the output
+                          volume is mounted.
+                        type: string
+                      pvc:
+                        description: PVC is the name of an existing PVC to use. If
+                          empty, the operator creates one named "{team}-output".
+                        type: string
+                      size:
+                        default: 5Gi
+                        description: Size of the auto-created PVC.
+                        type: string
+                      storageClass:
+                        description: StorageClass for the auto-created PVC. Defaults
+                          to "nfs".
+                        type: string
+                    type: object
+                type: object
+            required:
+            - auth
+            - lead
+            - templateRef
+            type: object
+          status:
+            description: AgentTeamStatus defines the observed state of an AgentTeam.
+            properties:
+              completedAt:
+                description: CompletedAt is when the team finished execution.
+                format: date-time
+                type: string
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              estimatedCost:
+                description: EstimatedCost is the estimated API cost in USD (e.g.
+                  "4.50").
+                type: string
+              lead:
+                description: Lead reports the team lead's status.
+                properties:
+                  phase:
+                    description: Phase of this agent.
+                    enum:
+                    - Pending
+                    - Running
+                    - Idle
+                    - Completed
+                    - Failed
+                    - Waiting
+                    type: string
+                  podName:
+                    description: PodName is the name of the agent's pod.
+                    type: string
+                type: object
+              phase:
+                description: Phase is the current lifecycle phase of the team.
+                enum:
+                - Pending
+                - Initializing
+                - Running
+                - Completed
+                - Failed
+                - TimedOut
+                - BudgetExceeded
+                type: string
+              pullRequest:
+                description: PullRequest reports PR creation status.
+                properties:
+                  state:
+                    type: string
+                  url:
+                    type: string
+                type: object
+              ready:
+                description: |-
+                  Ready reports how many teammate pods are ready vs. declared, in the form
+                  "running+completed/total" (e.g. "3/5"). Shown in `kubectl get` output.
+                type: string
+              startedAt:
+                description: StartedAt is when the team began execution.
+                format: date-time
+                type: string
+              tasks:
+                description: Tasks reports aggregate task progress.
+                properties:
+                  completed:
+                    type: integer
+                  inProgress:
+                    type: integer
+                  pending:
+                    type: integer
+                  total:
+                    type: integer
+                required:
+                - completed
+                - inProgress
+                - pending
+                - total
+                type: object
+              teammates:
+                description: Teammates reports each teammate's status.
+                items:
+                  description: TeammateStatus reports a teammate's state.
+                  properties:
+                    name:
+                      description: Name matches the teammate's spec name.
+                      type: string
+                    pendingApproval:
+                      description: PendingApproval is the approval gate event this
+                        teammate is waiting on, if any.
+                      type: string
+                    phase:
+                      description: Phase of this agent.
+                      enum:
+                      - Pending
+                      - Running
+                      - Idle
+                      - Completed
+                      - Failed
+                      - Waiting
+                      type: string
+                    podName:
+                      description: PodName is the name of the agent's pod.
+                      type: string
+                    tasksClaimed:
+                      description: TasksClaimed is the number of tasks currently owned
+                        by this teammate.
+                      type: integer
+                    tasksCompleted:
+                      description: TasksCompleted is the number of tasks this teammate
+                        has finished.
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+              totalTokensUsed:
+                description: TotalTokensUsed is the estimated total tokens consumed.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/claude-teams-operator/crds/claude.amcheste.io_agentteams.yaml
+++ b/charts/claude-teams-operator/crds/claude.amcheste.io_agentteams.yaml
@@ -1,0 +1,801 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  name: agentteams.claude.amcheste.io
+spec:
+  group: claude.amcheste.io
+  names:
+    kind: AgentTeam
+    listKind: AgentTeamList
+    plural: agentteams
+    singular: agentteam
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.ready
+      name: Ready
+      type: string
+    - jsonPath: .status.tasks.completed
+      name: Tasks Done
+      type: integer
+    - jsonPath: .status.estimatedCost
+      name: Cost
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AgentTeam is the Schema for the agentteams API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AgentTeamSpec defines the desired state of an AgentTeam.
+            properties:
+              auth:
+                description: Auth configures how agents authenticate with the Anthropic
+                  API.
+                properties:
+                  apiKeySecret:
+                    description: APIKeySecret references a Secret containing ANTHROPIC_API_KEY.
+                    type: string
+                  oauthSecret:
+                    description: OAuthSecret references a Secret containing OAuth
+                      tokens for subscription auth.
+                    type: string
+                type: object
+              coordination:
+                description: Coordination configures how agents communicate.
+                properties:
+                  beads:
+                    description: Beads configures optional Beads integration for persistent
+                      tracking.
+                    properties:
+                      doltServerPort:
+                        default: 3306
+                        description: DoltServerPort is the port for the Dolt SQL server.
+                        format: int32
+                        type: integer
+                      doltServerService:
+                        description: DoltServerService is the K8s service name for
+                          the Dolt SQL server.
+                        type: string
+                      enabled:
+                        description: Enabled turns on Beads tracking.
+                        type: boolean
+                    required:
+                    - enabled
+                    type: object
+                  mailboxBackend:
+                    default: shared-volume
+                    description: MailboxBackend determines how mailbox messages are
+                      transported.
+                    enum:
+                    - shared-volume
+                    - redis
+                    - nats
+                    type: string
+                  taskBackend:
+                    default: shared-volume
+                    description: TaskBackend determines how the shared task list is
+                      stored.
+                    enum:
+                    - shared-volume
+                    - beads
+                    type: string
+                type: object
+              lead:
+                description: Lead configures the team lead agent.
+                properties:
+                  mcpServers:
+                    description: MCPServers configures Model Context Protocol connections
+                      for the lead agent.
+                    items:
+                      description: MCPServerSpec configures a Model Context Protocol
+                        server for an agent.
+                      properties:
+                        credentialsSecret:
+                          description: CredentialsSecret references a Secret containing
+                            an 'apiKey' key for bearer auth.
+                          type: string
+                        name:
+                          description: Name identifies this MCP server in the agent's
+                            config.
+                          type: string
+                        url:
+                          description: URL is the MCP server endpoint.
+                          type: string
+                      required:
+                      - name
+                      - url
+                      type: object
+                    type: array
+                  model:
+                    default: opus
+                    description: Model to use for the team lead.
+                    enum:
+                    - opus
+                    - sonnet
+                    - haiku
+                    type: string
+                  permissionMode:
+                    default: auto-accept
+                    description: PermissionMode controls how the lead handles permission
+                      requests.
+                    enum:
+                    - auto-accept
+                    - plan
+                    - default
+                    type: string
+                  prompt:
+                    description: Prompt is the initial instruction for the team lead.
+                    type: string
+                  resources:
+                    description: Resources defines compute resources for the lead
+                      pod.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  skills:
+                    description: Skills to mount into .claude/skills/ for the lead
+                      agent.
+                    items:
+                      description: SkillSpec defines a Claude Code skill to mount
+                        into an agent pod.
+                      properties:
+                        name:
+                          description: Name is the skill directory name under .claude/skills/.
+                          type: string
+                        source:
+                          description: Source identifies where to load the skill from.
+                          properties:
+                            configMap:
+                              description: |-
+                                ConfigMap references a ConfigMap in the same namespace.
+                                Each key in the ConfigMap becomes a file in the skill directory.
+                              type: string
+                            oci:
+                              description: OCI is an OCI artifact reference containing
+                                the skill files (e.g. "ghcr.io/org/skills/web-research:v1").
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      - source
+                      type: object
+                    type: array
+                required:
+                - prompt
+                type: object
+              lifecycle:
+                description: Lifecycle configures team runtime behavior and budget.
+                properties:
+                  approvalGates:
+                    description: |-
+                      ApprovalGates pause execution before specified events until human approval is recorded.
+                      Grant approval by annotating the AgentTeam: kubectl annotate agentteam <name> approved.claude.amcheste.io/<event>=true
+                    items:
+                      description: |-
+                        ApprovalGateSpec pauses execution before a named event until human approval is recorded.
+                        Approval is granted by adding the annotation approved.claude.amcheste.io/{event}=true to the AgentTeam.
+                      properties:
+                        channel:
+                          default: none
+                          description: Channel is how the approval request notification
+                            is sent.
+                          enum:
+                          - webhook
+                          - none
+                          type: string
+                        event:
+                          description: Event is the gate identifier. Use "spawn-{teammate-name}"
+                            to gate spawning a specific teammate.
+                          type: string
+                        webhookUrl:
+                          description: WebhookURL to POST when this gate is triggered
+                            (used when channel is "webhook").
+                          type: string
+                      required:
+                      - event
+                      type: object
+                    type: array
+                  budgetLimit:
+                    description: BudgetLimit is the maximum API spend in USD before
+                      the team is terminated (e.g. "10.00").
+                    type: string
+                  onComplete:
+                    default: notify
+                    description: OnComplete determines what happens when the team
+                      finishes.
+                    enum:
+                    - create-pr
+                    - push-branch
+                    - notify
+                    - none
+                    type: string
+                  pullRequest:
+                    description: PullRequest configures PR creation when onComplete
+                      is "create-pr".
+                    properties:
+                      labels:
+                        description: Labels to apply to the PR.
+                        items:
+                          type: string
+                        type: array
+                      reviewers:
+                        description: Reviewers to request on the PR.
+                        items:
+                          type: string
+                        type: array
+                      targetBranch:
+                        default: main
+                        description: TargetBranch is the branch to open the PR against.
+                        type: string
+                      titleTemplate:
+                        description: |-
+                          TitleTemplate is a Go template for the PR title.
+                          Available variables: .TeamName, .Namespace
+                        type: string
+                    type: object
+                  timeout:
+                    default: 4h
+                    description: Timeout is the maximum duration the team can run
+                      (e.g. "4h", "30m").
+                    type: string
+                type: object
+              observability:
+                description: Observability configures metrics and notifications.
+                properties:
+                  logLevel:
+                    default: info
+                    description: LogLevel controls operator log verbosity for this
+                      team.
+                    enum:
+                    - debug
+                    - info
+                    - warn
+                    - error
+                    type: string
+                  metrics:
+                    description: Metrics configures Prometheus metrics exposition.
+                    properties:
+                      enabled:
+                        description: Enabled turns on metrics exposition.
+                        type: boolean
+                      port:
+                        default: 9090
+                        description: Port for the metrics endpoint.
+                        format: int32
+                        type: integer
+                    required:
+                    - enabled
+                    type: object
+                  webhook:
+                    description: Webhook configures event notifications.
+                    properties:
+                      events:
+                        description: Events to send notifications for.
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
+                      url:
+                        description: URL to POST events to.
+                        type: string
+                    required:
+                    - events
+                    - url
+                    type: object
+                type: object
+              qualityGates:
+                description: QualityGates configures validation before marking team
+                  complete.
+                properties:
+                  requireLint:
+                    description: RequireLint ensures linting passes before completion.
+                    type: boolean
+                  requireTests:
+                    description: RequireTests ensures tests pass before completion.
+                    type: boolean
+                  validationScript:
+                    description: ValidationScript is a custom script to run before
+                      marking complete.
+                    type: string
+                type: object
+              repository:
+                description: |-
+                  Repository configuration for the codebase agents will work on.
+                  Use this for coding tasks. Optional when Workspace is set.
+                properties:
+                  branch:
+                    default: main
+                    description: Branch to clone and work from.
+                    type: string
+                  credentialsSecret:
+                    description: |-
+                      CredentialsSecret references a Secret containing git credentials.
+                      The secret should contain either 'ssh-privatekey' or 'token'.
+                    type: string
+                  url:
+                    description: URL is the git clone URL.
+                    type: string
+                  worktreeStrategy:
+                    default: per-teammate
+                    description: WorktreeStrategy determines how git worktrees are
+                      managed.
+                    enum:
+                    - per-teammate
+                    - shared
+                    type: string
+                required:
+                - url
+                type: object
+              teammates:
+                description: Teammates defines the worker agents in the team.
+                items:
+                  description: TeammateSpec defines a single teammate agent.
+                  properties:
+                    dependsOn:
+                      description: DependsOn lists teammate names that must complete
+                        before this one starts.
+                      items:
+                        type: string
+                      type: array
+                    mcpServers:
+                      description: MCPServers configures Model Context Protocol connections
+                        for this teammate.
+                      items:
+                        description: MCPServerSpec configures a Model Context Protocol
+                          server for an agent.
+                        properties:
+                          credentialsSecret:
+                            description: CredentialsSecret references a Secret containing
+                              an 'apiKey' key for bearer auth.
+                            type: string
+                          name:
+                            description: Name identifies this MCP server in the agent's
+                              config.
+                            type: string
+                          url:
+                            description: URL is the MCP server endpoint.
+                            type: string
+                        required:
+                        - name
+                        - url
+                        type: object
+                      type: array
+                    model:
+                      default: sonnet
+                      description: Model to use for this teammate.
+                      enum:
+                      - opus
+                      - sonnet
+                      - haiku
+                      type: string
+                    name:
+                      description: Name is the unique identifier for this teammate.
+                      pattern: ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$
+                      type: string
+                    prompt:
+                      description: Prompt is the spawn instruction for this teammate.
+                      type: string
+                    resources:
+                      description: Resources defines compute resources for this teammate's
+                        pod.
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
+
+                            This field depends on the
+                            DynamicResourceAllocation feature gate.
+
+                            This field is immutable. It can only be set for containers.
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                              request:
+                                description: |-
+                                  Request is the name chosen for a request in the referenced claim.
+                                  If empty, everything from the claim is made available, otherwise
+                                  only the result of this request.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                    scope:
+                      description: Scope restricts which files this teammate can access.
+                      properties:
+                        excludePaths:
+                          description: ExcludePaths lists paths the teammate should
+                            not modify.
+                          items:
+                            type: string
+                          type: array
+                        includePaths:
+                          description: IncludePaths lists paths the teammate should
+                            focus on.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    skills:
+                      description: Skills to mount into .claude/skills/ for this teammate.
+                      items:
+                        description: SkillSpec defines a Claude Code skill to mount
+                          into an agent pod.
+                        properties:
+                          name:
+                            description: Name is the skill directory name under .claude/skills/.
+                            type: string
+                          source:
+                            description: Source identifies where to load the skill
+                              from.
+                            properties:
+                              configMap:
+                                description: |-
+                                  ConfigMap references a ConfigMap in the same namespace.
+                                  Each key in the ConfigMap becomes a file in the skill directory.
+                                type: string
+                              oci:
+                                description: OCI is an OCI artifact reference containing
+                                  the skill files (e.g. "ghcr.io/org/skills/web-research:v1").
+                                type: string
+                            type: object
+                        required:
+                        - name
+                        - source
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  - prompt
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+              workspace:
+                description: |-
+                  Workspace configures non-git inputs and outputs for Cowork teams.
+                  Use this for knowledge-work tasks (documents, reports, email, etc.).
+                properties:
+                  inputs:
+                    description: Inputs are read-only volumes mounted into all agent
+                      pods.
+                    items:
+                      description: WorkspaceInputSpec defines a read-only input mounted
+                        into the agent pod.
+                      properties:
+                        configMap:
+                          description: ConfigMap references a ConfigMap to mount as
+                            a directory.
+                          type: string
+                        mountPath:
+                          description: MountPath is where to mount this input inside
+                            the container.
+                          type: string
+                        pvc:
+                          description: PVC references an existing PersistentVolumeClaim
+                            to mount read-only.
+                          type: string
+                      required:
+                      - mountPath
+                      type: object
+                    type: array
+                  output:
+                    description: Output configures the shared writable output volume.
+                    properties:
+                      mountPath:
+                        default: /workspace/output
+                        description: MountPath inside the container where the output
+                          volume is mounted.
+                        type: string
+                      pvc:
+                        description: PVC is the name of an existing PVC to use. If
+                          empty, the operator creates one named "{team}-output".
+                        type: string
+                      size:
+                        default: 5Gi
+                        description: Size of the auto-created PVC.
+                        type: string
+                      storageClass:
+                        description: StorageClass for the auto-created PVC. Defaults
+                          to "nfs".
+                        type: string
+                    type: object
+                type: object
+            required:
+            - auth
+            - lead
+            - teammates
+            type: object
+          status:
+            description: AgentTeamStatus defines the observed state of an AgentTeam.
+            properties:
+              completedAt:
+                description: CompletedAt is when the team finished execution.
+                format: date-time
+                type: string
+              conditions:
+                description: Conditions represent the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              estimatedCost:
+                description: EstimatedCost is the estimated API cost in USD (e.g.
+                  "4.50").
+                type: string
+              lead:
+                description: Lead reports the team lead's status.
+                properties:
+                  phase:
+                    description: Phase of this agent.
+                    enum:
+                    - Pending
+                    - Running
+                    - Idle
+                    - Completed
+                    - Failed
+                    - Waiting
+                    type: string
+                  podName:
+                    description: PodName is the name of the agent's pod.
+                    type: string
+                type: object
+              phase:
+                description: Phase is the current lifecycle phase of the team.
+                enum:
+                - Pending
+                - Initializing
+                - Running
+                - Completed
+                - Failed
+                - TimedOut
+                - BudgetExceeded
+                type: string
+              pullRequest:
+                description: PullRequest reports PR creation status.
+                properties:
+                  state:
+                    type: string
+                  url:
+                    type: string
+                type: object
+              ready:
+                description: |-
+                  Ready reports how many teammate pods are ready vs. declared, in the form
+                  "running+completed/total" (e.g. "3/5"). Shown in `kubectl get` output.
+                type: string
+              startedAt:
+                description: StartedAt is when the team began execution.
+                format: date-time
+                type: string
+              tasks:
+                description: Tasks reports aggregate task progress.
+                properties:
+                  completed:
+                    type: integer
+                  inProgress:
+                    type: integer
+                  pending:
+                    type: integer
+                  total:
+                    type: integer
+                required:
+                - completed
+                - inProgress
+                - pending
+                - total
+                type: object
+              teammates:
+                description: Teammates reports each teammate's status.
+                items:
+                  description: TeammateStatus reports a teammate's state.
+                  properties:
+                    name:
+                      description: Name matches the teammate's spec name.
+                      type: string
+                    pendingApproval:
+                      description: PendingApproval is the approval gate event this
+                        teammate is waiting on, if any.
+                      type: string
+                    phase:
+                      description: Phase of this agent.
+                      enum:
+                      - Pending
+                      - Running
+                      - Idle
+                      - Completed
+                      - Failed
+                      - Waiting
+                      type: string
+                    podName:
+                      description: PodName is the name of the agent's pod.
+                      type: string
+                    tasksClaimed:
+                      description: TasksClaimed is the number of tasks currently owned
+                        by this teammate.
+                      type: integer
+                    tasksCompleted:
+                      description: TasksCompleted is the number of tasks this teammate
+                        has finished.
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+              totalTokensUsed:
+                description: TotalTokensUsed is the estimated total tokens consumed.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/claude-teams-operator/crds/claude.amcheste.io_agentteamtemplates.yaml
+++ b/charts/claude-teams-operator/crds/claude.amcheste.io_agentteamtemplates.yaml
@@ -1,0 +1,348 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  name: agentteamtemplates.claude.amcheste.io
+spec:
+  group: claude.amcheste.io
+  names:
+    kind: AgentTeamTemplate
+    listKind: AgentTeamTemplateList
+    plural: agentteamtemplates
+    singular: agentteamtemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.description
+      name: Description
+      type: string
+    - jsonPath: .spec.teammates
+      name: Teammates
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AgentTeamTemplate is a reusable team definition.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AgentTeamTemplateSpec defines a reusable team pattern.
+            properties:
+              coordination:
+                description: Coordination configures how agents communicate.
+                properties:
+                  beads:
+                    description: Beads configures optional Beads integration for persistent
+                      tracking.
+                    properties:
+                      doltServerPort:
+                        default: 3306
+                        description: DoltServerPort is the port for the Dolt SQL server.
+                        format: int32
+                        type: integer
+                      doltServerService:
+                        description: DoltServerService is the K8s service name for
+                          the Dolt SQL server.
+                        type: string
+                      enabled:
+                        description: Enabled turns on Beads tracking.
+                        type: boolean
+                    required:
+                    - enabled
+                    type: object
+                  mailboxBackend:
+                    default: shared-volume
+                    description: MailboxBackend determines how mailbox messages are
+                      transported.
+                    enum:
+                    - shared-volume
+                    - redis
+                    - nats
+                    type: string
+                  taskBackend:
+                    default: shared-volume
+                    description: TaskBackend determines how the shared task list is
+                      stored.
+                    enum:
+                    - shared-volume
+                    - beads
+                    type: string
+                type: object
+              description:
+                description: Description explains the template's purpose.
+                type: string
+              lifecycle:
+                description: Lifecycle configures default runtime behavior.
+                properties:
+                  approvalGates:
+                    description: |-
+                      ApprovalGates pause execution before specified events until human approval is recorded.
+                      Grant approval by annotating the AgentTeam: kubectl annotate agentteam <name> approved.claude.amcheste.io/<event>=true
+                    items:
+                      description: |-
+                        ApprovalGateSpec pauses execution before a named event until human approval is recorded.
+                        Approval is granted by adding the annotation approved.claude.amcheste.io/{event}=true to the AgentTeam.
+                      properties:
+                        channel:
+                          default: none
+                          description: Channel is how the approval request notification
+                            is sent.
+                          enum:
+                          - webhook
+                          - none
+                          type: string
+                        event:
+                          description: Event is the gate identifier. Use "spawn-{teammate-name}"
+                            to gate spawning a specific teammate.
+                          type: string
+                        webhookUrl:
+                          description: WebhookURL to POST when this gate is triggered
+                            (used when channel is "webhook").
+                          type: string
+                      required:
+                      - event
+                      type: object
+                    type: array
+                  budgetLimit:
+                    description: BudgetLimit is the maximum API spend in USD before
+                      the team is terminated (e.g. "10.00").
+                    type: string
+                  onComplete:
+                    default: notify
+                    description: OnComplete determines what happens when the team
+                      finishes.
+                    enum:
+                    - create-pr
+                    - push-branch
+                    - notify
+                    - none
+                    type: string
+                  pullRequest:
+                    description: PullRequest configures PR creation when onComplete
+                      is "create-pr".
+                    properties:
+                      labels:
+                        description: Labels to apply to the PR.
+                        items:
+                          type: string
+                        type: array
+                      reviewers:
+                        description: Reviewers to request on the PR.
+                        items:
+                          type: string
+                        type: array
+                      targetBranch:
+                        default: main
+                        description: TargetBranch is the branch to open the PR against.
+                        type: string
+                      titleTemplate:
+                        description: |-
+                          TitleTemplate is a Go template for the PR title.
+                          Available variables: .TeamName, .Namespace
+                        type: string
+                    type: object
+                  timeout:
+                    default: 4h
+                    description: Timeout is the maximum duration the team can run
+                      (e.g. "4h", "30m").
+                    type: string
+                type: object
+              qualityGates:
+                description: QualityGates configures default validation steps.
+                properties:
+                  requireLint:
+                    description: RequireLint ensures linting passes before completion.
+                    type: boolean
+                  requireTests:
+                    description: RequireTests ensures tests pass before completion.
+                    type: boolean
+                  validationScript:
+                    description: ValidationScript is a custom script to run before
+                      marking complete.
+                    type: string
+                type: object
+              teammates:
+                description: Teammates defines the worker agents in the template.
+                items:
+                  description: TeammateSpec defines a single teammate agent.
+                  properties:
+                    dependsOn:
+                      description: DependsOn lists teammate names that must complete
+                        before this one starts.
+                      items:
+                        type: string
+                      type: array
+                    mcpServers:
+                      description: MCPServers configures Model Context Protocol connections
+                        for this teammate.
+                      items:
+                        description: MCPServerSpec configures a Model Context Protocol
+                          server for an agent.
+                        properties:
+                          credentialsSecret:
+                            description: CredentialsSecret references a Secret containing
+                              an 'apiKey' key for bearer auth.
+                            type: string
+                          name:
+                            description: Name identifies this MCP server in the agent's
+                              config.
+                            type: string
+                          url:
+                            description: URL is the MCP server endpoint.
+                            type: string
+                        required:
+                        - name
+                        - url
+                        type: object
+                      type: array
+                    model:
+                      default: sonnet
+                      description: Model to use for this teammate.
+                      enum:
+                      - opus
+                      - sonnet
+                      - haiku
+                      type: string
+                    name:
+                      description: Name is the unique identifier for this teammate.
+                      pattern: ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$
+                      type: string
+                    prompt:
+                      description: Prompt is the spawn instruction for this teammate.
+                      type: string
+                    resources:
+                      description: Resources defines compute resources for this teammate's
+                        pod.
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
+
+                            This field depends on the
+                            DynamicResourceAllocation feature gate.
+
+                            This field is immutable. It can only be set for containers.
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                              request:
+                                description: |-
+                                  Request is the name chosen for a request in the referenced claim.
+                                  If empty, everything from the claim is made available, otherwise
+                                  only the result of this request.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                    scope:
+                      description: Scope restricts which files this teammate can access.
+                      properties:
+                        excludePaths:
+                          description: ExcludePaths lists paths the teammate should
+                            not modify.
+                          items:
+                            type: string
+                          type: array
+                        includePaths:
+                          description: IncludePaths lists paths the teammate should
+                            focus on.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    skills:
+                      description: Skills to mount into .claude/skills/ for this teammate.
+                      items:
+                        description: SkillSpec defines a Claude Code skill to mount
+                          into an agent pod.
+                        properties:
+                          name:
+                            description: Name is the skill directory name under .claude/skills/.
+                            type: string
+                          source:
+                            description: Source identifies where to load the skill
+                              from.
+                            properties:
+                              configMap:
+                                description: |-
+                                  ConfigMap references a ConfigMap in the same namespace.
+                                  Each key in the ConfigMap becomes a file in the skill directory.
+                                type: string
+                              oci:
+                                description: OCI is an OCI artifact reference containing
+                                  the skill files (e.g. "ghcr.io/org/skills/web-research:v1").
+                                type: string
+                            type: object
+                        required:
+                        - name
+                        - source
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  - prompt
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+            - teammates
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}


### PR DESCRIPTION
## Summary

`helm install charts/claude-teams-operator` was deploying the operator Deployment + RBAC but **not** the three `AgentTeam` CRDs. The operator then crash-looped trying to watch resources that didn't exist. Both `hack/e2e-setup.sh` and `hack/acceptance-setup.sh` silently papered over this by running `kubectl apply -f config/crd/bases/` before deploying.

This bug shipped in v0.1.0. Catching it before v0.2.0 goes out.

## Changes

- **`charts/claude-teams-operator/crds/`** — added the three CRD manifests. Helm's convention is that files under `crds/` are applied on `helm install` but not on upgrade (deliberate, to avoid destroying user-created CRs on chart upgrades).
- **`Makefile`** — `make manifests` now copies `config/crd/bases/*.yaml` into the chart's `crds/` dir after controller-gen runs, so the two locations can't drift. The validate workflow's "Check manifests are up to date" step will enforce this.

## Test plan

- [x] `make manifests` regenerates cleanly with no diff.
- [x] `helm template --include-crds charts/claude-teams-operator` now renders 3 CRDs plus the existing ServiceAccount, ClusterRole, ClusterRoleBinding, and Deployment (7 resources total).
- [x] `helm lint charts/claude-teams-operator` passes.
- [ ] End-to-end verified on the next v0.2.0 tag push via `helm install oci://...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)