### PR TITLE
fix(hack): bump kind-setup helm install timeout to 15m

### DIFF
--- a/hack/kind-setup.sh
+++ b/hack/kind-setup.sh
@@ -37,7 +37,14 @@ helm install nfs-server nfs-ganesha/nfs-server-provisioner \
   --set persistence.size=50Gi \
   --set storageClass.name=nfs \
   --set storageClass.defaultClass=false \
-  --wait
+  --wait \
+  --timeout=15m
+# 15m is deliberate: the nfs-provisioner image is ~500MB and first-time
+# pulls routinely take 5–10 minutes on home connections or behind slow
+# registry mirrors. Helm's default --wait timeout of 5m was hitting failures
+# here even though the deployment itself was healthy; the resources would
+# come up a minute later but with the release marked "failed", confusing
+# contributors into thinking the setup was broken.
 
 echo ""
 echo "[3/5] Creating dev-agents namespace"


### PR DESCRIPTION
## Summary

`hack/kind-setup.sh` runs `helm install nfs-server ... --wait` without a custom timeout, inheriting Helm's 5-minute default. The `nfs-provisioner:v4.0.8` image is ~500 MB — first-time pulls on home connections or slow registry mirrors routinely take 5–10 minutes. When `--wait` times out, Helm marks the release `failed` even though the resources become healthy a minute later, confusing contributors into thinking the setup is broken.

Hit this during v0.2.0 release-prep testing: pod came Ready at 8m47s, but `make kind-create` had already exited with an error. The StorageClass and StatefulSet were fine — only the Helm release status was wrong.

## Change

Adds `--timeout=15m` to the helm install. 15m is deliberate: comfortable headroom over the observed 8m47s without being unreasonable. Inline comment explains the reasoning so future readers don't "clean this up" back to the default.

## Test plan

- [x] `shellcheck hack/kind-setup.sh` — clean.
- [ ] Next `make kind-create` cold-cache run completes without failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)