### PR TITLE
chore: auto-assign PR creator

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,21 @@
+name: Auto-assign PR creator
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [context.payload.pull_request.user.login]
+            });


### PR DESCRIPTION
## Summary
- Adds a GitHub Action that automatically assigns every new PR to whoever opened it
- Ensures PRs show up in Graphite and GitHub dashboards without manual assignment

## Test plan
- [x] Workflow syntax is valid YAML
- [ ] Open a test PR after merge to confirm assignment works

Generated with [Claude Code](https://claude.com/claude-code)