### PR TITLE
fix(ci): pin setup-envtest to release-0.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ helm-uninstall: ## Uninstall Helm release
 ##@ Testing
 
 ENVTEST_K8S_VERSION ?= 1.31
+ENVTEST_VERSION ?= release-0.23
 SETUP_ENVTEST = $(shell go env GOPATH)/bin/setup-envtest
 
 .PHONY: test-integration
@@ -161,7 +162,7 @@ e2e-down: ## Tear down Kind E2E cluster
 
 .PHONY: envtest
 envtest: ## Install setup-envtest
-	@test -f $(SETUP_ENVTEST) || go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	@test -f $(SETUP_ENVTEST) || go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 ##@ Tools
 


### PR DESCRIPTION
## Summary
- `setup-envtest@latest` now resolves to a version that requires Go 1.26, which breaks CI (Go 1.25.0 from `go.mod`).
- Pin `setup-envtest` to the `release-0.23` branch to track controller-runtime v0.23.x — the version this project depends on.
- Unblocks dependabot PRs like [#106](https://github.com/amcheste/claude-teams-operator/pull/106) whose unit-test job was failing at `Install setup-envtest`.

## Test plan
- [x] `rm $(go env GOPATH)/bin/setup-envtest && make envtest` installs a Go 1.25-compatible build locally
- [ ] CI `Unit & Integration Tests` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)