### PR TITLE
feat(chart): ship Service, ServiceMonitor, and Grafana dashboard (#12)

### DIFF
--- a/charts/claude-teams-operator/dashboards/claude-teams.json
+++ b/charts/claude-teams-operator/dashboards/claude-teams.json
@@ -1,0 +1,440 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Claude Agent Teams — live view of active teams, cost burn, budget headroom, and teammate health. Metrics are exported by the claude-teams-operator.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "id": 1,
+      "title": "Active Teams",
+      "type": "stat",
+      "gridPos": {"h": 5, "w": 6, "x": 0, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "expr": "claude_team_active_total",
+          "legendFormat": "active",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 5},
+              {"color": "red", "value": 10}
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      }
+    },
+    {
+      "id": 2,
+      "title": "Teams Completed (last 1h)",
+      "type": "stat",
+      "gridPos": {"h": 5, "w": 6, "x": 6, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "expr": "sum(increase(claude_team_duration_seconds_count[1h]))",
+          "legendFormat": "completed",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "mappings": [],
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      }
+    },
+    {
+      "id": 3,
+      "title": "Teammate Restarts (last 1h)",
+      "type": "stat",
+      "gridPos": {"h": 5, "w": 6, "x": 12, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "expr": "sum(increase(claude_teammate_restarts_total[1h]))",
+          "legendFormat": "restarts",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 1},
+              {"color": "red", "value": 5}
+            ]
+          },
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      }
+    },
+    {
+      "id": 4,
+      "title": "Total Cost (last 1h)",
+      "type": "stat",
+      "gridPos": {"h": 5, "w": 6, "x": 18, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "expr": "sum(claude_team_cost_usd)",
+          "legendFormat": "USD",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 10},
+              {"color": "red", "value": 50}
+            ]
+          },
+          "unit": "currencyUSD",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      }
+    },
+    {
+      "id": 5,
+      "title": "Active Teams Over Time",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 5},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "expr": "claude_team_active_total",
+          "legendFormat": "active",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {"group": "A", "mode": "none"},
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"calcs": ["last"], "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "single", "sort": "none"}
+      }
+    },
+    {
+      "id": 6,
+      "title": "Cost per Team (USD)",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 5},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "expr": "claude_team_cost_usd",
+          "legendFormat": "{{namespace}}/{{team}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {"group": "A", "mode": "none"},
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "currencyUSD",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "id": 7,
+      "title": "Budget Remaining per Team (USD)",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 13},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "expr": "claude_team_budget_remaining_usd",
+          "legendFormat": "{{namespace}}/{{team}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {"group": "A", "mode": "none"},
+            "axisPlacement": "auto",
+            "thresholdsStyle": {"mode": "line"}
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": 0}
+            ]
+          },
+          "unit": "currencyUSD",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "min"], "displayMode": "table", "placement": "right"},
+        "tooltip": {"mode": "multi", "sort": "asc"}
+      }
+    },
+    {
+      "id": 8,
+      "title": "Teammate Restarts per Team",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 13},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "expr": "sum by (team, teammate) (increase(claude_teammate_restarts_total[5m]))",
+          "legendFormat": "{{team}}/{{teammate}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 70,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {"group": "A", "mode": "normal"},
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"calcs": ["sum"], "displayMode": "table", "placement": "right"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "id": 9,
+      "title": "Token Consumption Rate (tokens/sec per teammate)",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 21},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "expr": "sum by (team, teammate, model) (rate(claude_teammate_tokens_total[5m]))",
+          "legendFormat": "{{team}}/{{teammate}} ({{model}})",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {"group": "A", "mode": "none"},
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "id": 10,
+      "title": "Team Duration (p50 / p90 / p99)",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 21},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(claude_team_duration_seconds_bucket[1h])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(claude_team_duration_seconds_bucket[1h])))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(claude_team_duration_seconds_bucket[1h])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {"group": "A", "mode": "none"},
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom"},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["claude", "agent-teams", "kubernetes"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": false, "text": "Prometheus", "value": "prometheus"},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "Claude Agent Teams",
+  "uid": "claude-agent-teams",
+  "version": 1,
+  "weekStart": ""
+}

--- a/charts/claude-teams-operator/templates/grafana-dashboard.yaml
+++ b/charts/claude-teams-operator/templates/grafana-dashboard.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.metrics.grafanaDashboard.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-grafana-dashboard
+  namespace: {{ default .Release.Namespace .Values.metrics.grafanaDashboard.namespace }}
+  labels:
+    app.kubernetes.io/name: claude-teams-operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: dashboard
+    {{- with .Values.metrics.grafanaDashboard.sidecarLabel }}
+    {{ . }}: {{ $.Values.metrics.grafanaDashboard.sidecarLabelValue | quote }}
+    {{- end }}
+    {{- with .Values.metrics.grafanaDashboard.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  claude-teams.json: |-
+{{ .Files.Get "dashboards/claude-teams.json" | indent 4 }}
+{{- end }}

--- a/charts/claude-teams-operator/templates/service.yaml
+++ b/charts/claude-teams-operator/templates/service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: claude-teams-operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: metrics
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: claude-teams-operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+{{- end }}

--- a/charts/claude-teams-operator/templates/servicemonitor.yaml
+++ b/charts/claude-teams-operator/templates/servicemonitor.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-metrics
+  namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace }}
+  labels:
+    app.kubernetes.io/name: claude-teams-operator
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: metrics
+    {{- with .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: claude-teams-operator
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: metrics
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      path: /metrics
+{{- end }}

--- a/charts/claude-teams-operator/values.yaml
+++ b/charts/claude-teams-operator/values.yaml
@@ -38,9 +38,32 @@ metrics:
   enabled: true
   port: 8080
   serviceMonitor:
+    # Set to true when kube-prometheus-stack (or another Prometheus Operator
+    # install) is present. Requires the monitoring.coreos.com CRDs.
     enabled: false
+    # Namespace to install the ServiceMonitor into. Defaults to the release
+    # namespace. Set to the Prometheus namespace when using a namespace-scoped
+    # ServiceMonitor selector.
     namespace: ""
     interval: 30s
+    # Extra labels applied to the ServiceMonitor. Use this to match the label
+    # selector on your Prometheus CR (e.g. release: kube-prometheus-stack).
+    additionalLabels: {}
+  grafanaDashboard:
+    # Renders a ConfigMap containing a Grafana dashboard JSON for Claude team
+    # observability. With the stock kube-prometheus-stack, the Grafana sidecar
+    # auto-imports any ConfigMap carrying `grafana_dashboard: "1"`.
+    enabled: false
+    # Namespace to install the dashboard ConfigMap into. Defaults to the
+    # release namespace. Many setups require this to match the Grafana
+    # namespace so the sidecar picks it up.
+    namespace: ""
+    # Label the Grafana sidecar watches for. Stock kube-prometheus-stack uses
+    # `grafana_dashboard`. Set to "" to disable the sidecar label entirely.
+    sidecarLabel: "grafana_dashboard"
+    sidecarLabelValue: "1"
+    # Extra labels applied to the ConfigMap.
+    additionalLabels: {}
 
 # Health probes
 healthProbe:


### PR DESCRIPTION
Closes #12.

## Summary
- Adds three Helm templates: `Service` (metrics port 8080), `ServiceMonitor` (for kube-prometheus-stack), and a `ConfigMap`-based Grafana dashboard with the sidecar auto-import label.
- 10-panel dashboard covering the full KubeCon demo narrative: active teams, cost burn, budget headroom, teammate restarts, token rate, duration p50/p90/p99.
- All three resources are independently gated:
  - `metrics.enabled` → Service (default **on**)
  - `metrics.serviceMonitor.enabled` → ServiceMonitor (default **off**)
  - `metrics.grafanaDashboard.enabled` → dashboard ConfigMap (default **off**)

## Dashboard panels
| # | Title | Query |
|---|---|---|
| 1 | Active Teams | `claude_team_active_total` |
| 2 | Teams Completed (1h) | `sum(increase(claude_team_duration_seconds_count[1h]))` |
| 3 | Teammate Restarts (1h) | `sum(increase(claude_teammate_restarts_total[1h]))` |
| 4 | Total Cost (1h) | `sum(claude_team_cost_usd)` |
| 5 | Active Teams Over Time | `claude_team_active_total` |
| 6 | Cost per Team | `claude_team_cost_usd` |
| 7 | Budget Remaining per Team | `claude_team_budget_remaining_usd` |
| 8 | Teammate Restarts per Team | `sum by (team, teammate) (increase(claude_teammate_restarts_total[5m]))` |
| 9 | Token Consumption Rate | `sum by (team, teammate, model) (rate(claude_teammate_tokens_total[5m]))` |
| 10 | Team Duration p50/p90/p99 | `histogram_quantile(...)` |

## Design notes
- **Dashboard JSON lives in its own file** (`charts/claude-teams-operator/dashboards/claude-teams.json`) slurped via `.Files.Get` — keeps the JSON editable in Grafana's UI and re-exportable without Helm templating noise.
- **Sidecar label auto-import:** stock kube-prometheus-stack mounts any ConfigMap carrying `grafana_dashboard: "1"` into Grafana — no provisioning YAML needed. Label is configurable via `metrics.grafanaDashboard.sidecarLabel` for non-standard setups.
- **ServiceMonitor can live in a different namespace** (via `metrics.serviceMonitor.namespace`) for setups where Prometheus runs out-of-namespace.

## Test plan
- [x] `helm lint ./charts/claude-teams-operator` — clean with defaults
- [x] `helm lint ./charts/claude-teams-operator --set metrics.serviceMonitor.enabled=true --set metrics.grafanaDashboard.enabled=true` — clean
- [x] `helm template` with defaults → Service renders, ServiceMonitor/ConfigMap do not
- [x] `helm template --set metrics.enabled=false` → no Service renders
- [x] Dashboard JSON extracted from rendered ConfigMap parses as valid JSON (10 panels, correct title/uid)
- [x] `go vet ./...` + `go test ./...` clean (no Go changes, sanity only)
- [ ] Manual: install with kube-prometheus-stack and confirm dashboard appears in Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)