### PR TITLE
feat(webhook): implement notifier and wire phase-transition events (#11)

### DIFF
--- a/internal/controller/agentteam_controller.go
+++ b/internal/controller/agentteam_controller.go
@@ -23,6 +23,7 @@ import (
 
 	claudev1alpha1 "github.com/amcheste/claude-teams-operator/api/v1alpha1"
 	"github.com/amcheste/claude-teams-operator/internal/metrics"
+	"github.com/amcheste/claude-teams-operator/internal/webhook"
 )
 
 const (
@@ -245,6 +246,10 @@ func (r *AgentTeamReconciler) reconcileInitializing(ctx context.Context, team *c
 	team.Status.Phase = "Running"
 	setCondition(team, metav1.ConditionTrue, "Running", "Agent pods deployed")
 	r.recordEvent(team, corev1.EventTypeNormal, "Running", "Agent pods deployed")
+	_ = teamNotifier(team).SendEvent(ctx, "team.started", teamEventPayload(team, map[string]interface{}{
+		"leadModel": team.Spec.Lead.Model,
+		"teammates": len(team.Spec.Teammates),
+	}))
 	return ctrl.Result{RequeueAfter: 30 * time.Second}, r.Status().Update(ctx, team)
 }
 
@@ -270,6 +275,7 @@ func (r *AgentTeamReconciler) reconcileRunning(ctx context.Context, team *claude
 	// Update cost estimate and check budget.
 	team.Status.EstimatedCost = estimateCost(team)
 	r.exportBudgetMetrics(team)
+	r.maybeFireBudgetWarning(ctx, team)
 	if r.isBudgetExceeded(team) {
 		log.Info("Budget exceeded", "cost", team.Status.EstimatedCost)
 		if err := r.terminateAllPods(ctx, team); err != nil {
@@ -319,6 +325,7 @@ func (r *AgentTeamReconciler) reconcileRunning(ctx context.Context, team *claude
 		team.Status.Phase = "Failed"
 		setCondition(team, metav1.ConditionFalse, "AgentFailed", "One or more agent pods failed")
 		r.recordEvent(team, corev1.EventTypeWarning, "AgentFailed", "One or more agent pods failed")
+		r.fireTeammateErrorEvents(ctx, team)
 		return ctrl.Result{}, r.Status().Update(ctx, team)
 	}
 	if allDone {
@@ -359,6 +366,62 @@ func (r *AgentTeamReconciler) reconcileTerminal(ctx context.Context, team *claud
 		return ctrl.Result{}, r.Status().Update(ctx, team)
 	}
 	return ctrl.Result{}, nil
+}
+
+// fireTeammateErrorEvents emits a `teammate.error` webhook event for every
+// failed pod belonging to this team. Called once at the transition into the
+// Failed phase so events do not repeat across reconciles.
+func (r *AgentTeamReconciler) fireTeammateErrorEvents(ctx context.Context, team *claudev1alpha1.AgentTeam) {
+	n := teamNotifier(team)
+	if n == nil {
+		return
+	}
+	check := func(teammateName, podName string) {
+		pod := &corev1.Pod{}
+		if err := r.Get(ctx, types.NamespacedName{Name: podName, Namespace: team.Namespace}, pod); err != nil {
+			return
+		}
+		if pod.Status.Phase != corev1.PodFailed {
+			return
+		}
+		_ = n.SendEvent(ctx, "teammate.error", teamEventPayload(team, map[string]interface{}{
+			"teammate": teammateName,
+			"pod":      podName,
+			"reason":   pod.Status.Reason,
+			"message":  pod.Status.Message,
+		}))
+	}
+	check("lead", agentPodName(team, "lead"))
+	for _, tm := range team.Spec.Teammates {
+		check(tm.Name, agentPodName(team, tm.Name))
+	}
+}
+
+// maybeFireBudgetWarning emits the `budget.warning` webhook event the first
+// time the team's estimated cost crosses 80% of its configured limit. Uses a
+// status Condition to dedupe across reconcile passes and operator restarts.
+// No-op when no budget is set or the threshold has not been reached.
+func (r *AgentTeamReconciler) maybeFireBudgetWarning(ctx context.Context, team *claudev1alpha1.AgentTeam) {
+	if team.Spec.Lifecycle == nil || team.Spec.Lifecycle.BudgetLimit == nil {
+		return
+	}
+	if budgetWarningSent(team) {
+		return
+	}
+	var limit, current float64
+	if _, err := fmt.Sscanf(*team.Spec.Lifecycle.BudgetLimit, "%f", &limit); err != nil || limit <= 0 {
+		return
+	}
+	fmt.Sscanf(team.Status.EstimatedCost, "%f", &current) //nolint:errcheck
+	if current < 0.8*limit {
+		return
+	}
+	_ = teamNotifier(team).SendEvent(ctx, "budget.warning", teamEventPayload(team, map[string]interface{}{
+		"estimatedCost": fmt.Sprintf("%.2f", current),
+		"budgetLimit":   fmt.Sprintf("%.2f", limit),
+		"threshold":     "80%",
+	}))
+	markBudgetWarningSent(team, current, limit)
 }
 
 // exportBudgetMetrics publishes the team's current estimated cost and remaining
@@ -1137,6 +1200,57 @@ func (r *AgentTeamReconciler) terminateAllPods(ctx context.Context, team *claude
 		}
 	}
 	return nil
+}
+
+// --- Webhook Helpers ---
+
+// teamNotifier returns a webhook.Notifier built from the team's Observability
+// config, or nil if no webhook is configured. The returned *Notifier is
+// nil-safe — callers may invoke SendEvent on it unconditionally.
+func teamNotifier(team *claudev1alpha1.AgentTeam) *webhook.Notifier {
+	if team.Spec.Observability == nil || team.Spec.Observability.Webhook == nil {
+		return nil
+	}
+	w := team.Spec.Observability.Webhook
+	return webhook.NewNotifier(w.URL, w.Events)
+}
+
+// teamEventPayload builds the standard webhook envelope fields (team, namespace)
+// merged with an event-specific `data` subobject.
+func teamEventPayload(team *claudev1alpha1.AgentTeam, data map[string]interface{}) map[string]interface{} {
+	payload := map[string]interface{}{
+		"team":      team.Name,
+		"namespace": team.Namespace,
+	}
+	if data != nil {
+		payload["data"] = data
+	}
+	return payload
+}
+
+// budgetWarningSent reports whether the 80% budget warning webhook has already
+// fired for this team. Persisted in the team's Conditions so it survives
+// operator restarts.
+func budgetWarningSent(team *claudev1alpha1.AgentTeam) bool {
+	for _, c := range team.Status.Conditions {
+		if c.Type == "BudgetWarningSent" && c.Status == metav1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// markBudgetWarningSent records that the budget warning webhook has fired so
+// subsequent reconciles do not re-fire it.
+func markBudgetWarningSent(team *claudev1alpha1.AgentTeam, cost, limit float64) {
+	now := metav1.Now()
+	team.Status.Conditions = append(team.Status.Conditions, metav1.Condition{
+		Type:               "BudgetWarningSent",
+		Status:             metav1.ConditionTrue,
+		Reason:             "ThresholdReached",
+		Message:            fmt.Sprintf("Estimated cost %.2f reached 80%% of budget limit %.2f", cost, limit),
+		LastTransitionTime: now,
+	})
 }
 
 // --- Condition Helpers ---

--- a/internal/controller/agentteam_webhook_test.go
+++ b/internal/controller/agentteam_webhook_test.go
@@ -1,0 +1,216 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	claudev1alpha1 "github.com/amcheste/claude-teams-operator/api/v1alpha1"
+)
+
+// webhookCaptureServer returns an httptest server that pushes every received
+// JSON body onto a channel. Used to assert that controller phase transitions
+// fire the expected webhook events.
+func webhookCaptureServer(t *testing.T) (url string, events <-chan map[string]interface{}) {
+	t.Helper()
+	ch := make(chan map[string]interface{}, 8)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var msg map[string]interface{}
+		_ = json.Unmarshal(body, &msg)
+		ch <- msg
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL, ch
+}
+
+func withWebhook(team *claudev1alpha1.AgentTeam, url string, events []string) *claudev1alpha1.AgentTeam {
+	team.Spec.Observability = &claudev1alpha1.ObservabilitySpec{
+		Webhook: &claudev1alpha1.WebhookSpec{URL: url, Events: events},
+	}
+	return team
+}
+
+// waitForEvent blocks up to 2s for a webhook POST to arrive. The notifier
+// POSTs asynchronously, so tests must await delivery rather than inspect
+// synchronously after the reconcile returns.
+func waitForEvent(t *testing.T, ch <-chan map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	select {
+	case msg := <-ch:
+		return msg
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for webhook delivery")
+		return nil
+	}
+}
+
+func TestReconcileInitializing_FiresTeamStartedWebhook(t *testing.T) {
+	url, events := webhookCaptureServer(t)
+
+	team := withWebhook(withRepo(minimalTeam("wh-start")), url, []string{"team.started"})
+	job := completedJob("wh-start-init", "default")
+	r := newReconciler(team, job)
+	team = fetch(t, r, "wh-start")
+	team.Spec.Observability = &claudev1alpha1.ObservabilitySpec{
+		Webhook: &claudev1alpha1.WebhookSpec{URL: url, Events: []string{"team.started"}},
+	}
+	require.NoError(t, r.Update(context.Background(), team))
+	team = fetch(t, r, "wh-start")
+	ctx := context.Background()
+
+	_, err := r.reconcileInitializing(ctx, team)
+	require.NoError(t, err)
+	assert.Equal(t, "Running", team.Status.Phase)
+
+	msg := waitForEvent(t, events)
+	assert.Equal(t, "team.started", msg["event"])
+	assert.Equal(t, "wh-start", msg["team"])
+	assert.Equal(t, "default", msg["namespace"])
+	assert.NotEmpty(t, msg["timestamp"])
+	data, ok := msg["data"].(map[string]interface{})
+	require.True(t, ok, "data subobject expected")
+	assert.Equal(t, "opus", data["leadModel"])
+}
+
+func TestReconcileRunning_FiresBudgetWarningAt80Percent(t *testing.T) {
+	url, events := webhookCaptureServer(t)
+
+	// estimateCost for minimalTeam (opus lead + sonnet worker) is ~$0.0315/min.
+	// At 5h elapsed that's ~$9.45 — 94.5% of a $10 budget, safely in the
+	// [80%, 100%) window so warning fires without the exceeded branch
+	// pre-empting the reconcile.
+	team := withWebhook(withLifecycle(minimalTeam("wh-budget"), "24h", "10.00"), url, []string{"budget.warning"})
+	team.Status.Phase = "Running"
+	start := metav1.NewTime(time.Now().Add(-5 * time.Hour))
+	team.Status.StartedAt = &start
+
+	r := newReconciler(team)
+	team = fetch(t, r, "wh-budget")
+	ctx := context.Background()
+
+	_, err := r.reconcileRunning(ctx, team)
+	require.NoError(t, err)
+
+	msg := waitForEvent(t, events)
+	assert.Equal(t, "budget.warning", msg["event"])
+	assert.Equal(t, "wh-budget", msg["team"])
+	data, ok := msg["data"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "80%", data["threshold"])
+	assert.Equal(t, "10.00", data["budgetLimit"])
+}
+
+func TestReconcileRunning_BudgetWarningFiresOnlyOnce(t *testing.T) {
+	// Subsequent reconciles must not re-fire the warning; the condition
+	// dedup must hold across calls.
+	url, events := webhookCaptureServer(t)
+
+	team := withWebhook(withLifecycle(minimalTeam("wh-budget-dedup"), "24h", "10.00"), url, []string{"budget.warning"})
+	team.Status.Phase = "Running"
+	start := metav1.NewTime(time.Now().Add(-5 * time.Hour))
+	team.Status.StartedAt = &start
+
+	r := newReconciler(team)
+	team = fetch(t, r, "wh-budget-dedup")
+	ctx := context.Background()
+
+	_, err := r.reconcileRunning(ctx, team)
+	require.NoError(t, err)
+	_ = waitForEvent(t, events) // first fire
+
+	// Re-fetch and run again — condition should block the second fire.
+	team = fetch(t, r, "wh-budget-dedup")
+	_, err = r.reconcileRunning(ctx, team)
+	require.NoError(t, err)
+
+	select {
+	case msg := <-events:
+		t.Fatalf("budget.warning fired twice: %v", msg)
+	case <-time.After(300 * time.Millisecond):
+		// Expected — no second delivery.
+	}
+}
+
+func TestReconcileRunning_FiresTeammateErrorOnPodFailure(t *testing.T) {
+	url, events := webhookCaptureServer(t)
+
+	team := withWebhook(minimalTeam("wh-fail"), url, []string{"teammate.error"})
+	team.Status.Phase = "Running"
+
+	// A teammate pod in Failed phase triggers anyFailed → fireTeammateErrorEvents.
+	leadPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wh-fail-lead",
+			Namespace: "default",
+			Labels:    map[string]string{"claude.amcheste.io/team": "wh-fail"},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
+	}
+	workerPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wh-fail-worker",
+			Namespace: "default",
+			Labels:    map[string]string{"claude.amcheste.io/team": "wh-fail"},
+		},
+		Status: corev1.PodStatus{
+			Phase:   corev1.PodFailed,
+			Reason:  "Error",
+			Message: "agent crashed",
+		},
+	}
+
+	r := newReconciler(team, leadPod, workerPod)
+	team = fetch(t, r, "wh-fail")
+	ctx := context.Background()
+
+	_, err := r.reconcileRunning(ctx, team)
+	require.NoError(t, err)
+	assert.Equal(t, "Failed", team.Status.Phase)
+
+	msg := waitForEvent(t, events)
+	assert.Equal(t, "teammate.error", msg["event"])
+	data, ok := msg["data"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "worker", data["teammate"])
+	assert.Equal(t, "wh-fail-worker", data["pod"])
+	assert.Equal(t, "Error", data["reason"])
+	assert.Equal(t, "agent crashed", data["message"])
+}
+
+func TestWebhookEvents_OnlySubscribedEventsFire(t *testing.T) {
+	// Team subscribed to ONLY team.completed — starting should not deliver
+	// anything.
+	url, events := webhookCaptureServer(t)
+
+	team := withWebhook(withRepo(minimalTeam("wh-filter")), url, []string{"team.completed"})
+	job := completedJob("wh-filter-init", "default")
+	r := newReconciler(team, job)
+	team = fetch(t, r, "wh-filter")
+	team.Spec.Observability = &claudev1alpha1.ObservabilitySpec{
+		Webhook: &claudev1alpha1.WebhookSpec{URL: url, Events: []string{"team.completed"}},
+	}
+	require.NoError(t, r.Update(context.Background(), team))
+	team = fetch(t, r, "wh-filter")
+	ctx := context.Background()
+
+	_, err := r.reconcileInitializing(ctx, team)
+	require.NoError(t, err)
+
+	select {
+	case msg := <-events:
+		t.Fatalf("unsubscribed team.started fired: %v", msg)
+	case <-time.After(300 * time.Millisecond):
+		// Expected.
+	}
+}

--- a/internal/webhook/notifier.go
+++ b/internal/webhook/notifier.go
@@ -1,0 +1,118 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// DefaultTimeout bounds a single webhook POST. A slow webhook must never stall
+// the reconciler, so deliveries run in a background goroutine with this
+// context deadline.
+const DefaultTimeout = 5 * time.Second
+
+// Notifier posts JSON event payloads to a configured webhook URL. The zero
+// value is not usable — construct via NewNotifier. A nil *Notifier is safe to
+// call SendEvent on and treats every call as a no-op, which lets controller
+// code emit events unconditionally when no webhook is configured.
+type Notifier struct {
+	url    string
+	events map[string]struct{}
+	client *http.Client
+
+	// inFlight lets tests wait for background POSTs to drain without exposing
+	// the internal goroutine to production callers. Production callers never
+	// need to wait; the runtime eats goroutine leaks at process exit.
+	inFlight sync.WaitGroup
+}
+
+// NewNotifier returns a Notifier configured to POST to url for the given event
+// types. Events not in the list are silently dropped by SendEvent. Returns nil
+// when url is empty so callers can unconditionally construct a notifier from
+// an optional CRD field and rely on the nil-safe SendEvent.
+func NewNotifier(url string, events []string) *Notifier {
+	if url == "" {
+		return nil
+	}
+	set := make(map[string]struct{}, len(events))
+	for _, e := range events {
+		set[e] = struct{}{}
+	}
+	return &Notifier{
+		url:    url,
+		events: set,
+		client: &http.Client{Timeout: DefaultTimeout},
+	}
+}
+
+// SendEvent dispatches an event to the configured webhook. It wraps payload in
+// the standard envelope `{event, timestamp, ...payload}` and POSTs the result
+// as JSON.
+//
+// Delivery happens in a background goroutine with a short timeout so a slow
+// webhook cannot stall the reconciler. SendEvent returns before the POST
+// completes; delivery errors are logged against the caller's context logger
+// and not returned.
+//
+// SendEvent returns synchronously only when the payload cannot be marshaled
+// (programmer error) or the event type is not subscribed (no-op, returns nil).
+// A nil receiver returns nil immediately.
+func (n *Notifier) SendEvent(ctx context.Context, eventType string, payload map[string]interface{}) error {
+	if n == nil {
+		return nil
+	}
+	if _, subscribed := n.events[eventType]; !subscribed {
+		return nil
+	}
+
+	envelope := make(map[string]interface{}, len(payload)+2)
+	for k, v := range payload {
+		envelope[k] = v
+	}
+	envelope["event"] = eventType
+	envelope["timestamp"] = time.Now().UTC().Format(time.RFC3339)
+
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		return fmt.Errorf("marshal webhook payload: %w", err)
+	}
+
+	logger := log.FromContext(ctx).WithValues("webhook", n.url, "event", eventType)
+
+	n.inFlight.Add(1)
+	go func() {
+		defer n.inFlight.Done()
+		n.post(logger, body)
+	}()
+	return nil
+}
+
+func (n *Notifier) post(logger logr.Logger, body []byte) {
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.url, bytes.NewReader(body))
+	if err != nil {
+		logger.Error(err, "build webhook request")
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := n.client.Do(req)
+	if err != nil {
+		logger.Error(err, "webhook POST failed")
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		logger.Error(fmt.Errorf("status %d", resp.StatusCode), "webhook returned non-2xx")
+	}
+}
+

--- a/internal/webhook/notifier_test.go
+++ b/internal/webhook/notifier_test.go
@@ -1,0 +1,214 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestServer returns a test server that captures every received JSON body
+// on the returned channel. Tests read from ch with a short timeout.
+func newTestServer(t *testing.T) (*httptest.Server, <-chan map[string]interface{}) {
+	t.Helper()
+	ch := make(chan map[string]interface{}, 8)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		var msg map[string]interface{}
+		if err := json.Unmarshal(body, &msg); err != nil {
+			t.Errorf("unmarshal body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		ch <- msg
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, ch
+}
+
+func TestNewNotifier_EmptyURLReturnsNil(t *testing.T) {
+	assert.Nil(t, NewNotifier("", []string{"team.started"}))
+}
+
+func TestNilNotifier_SendEventIsNoOp(t *testing.T) {
+	// Unconditionally calling SendEvent when no webhook is configured must not
+	// panic — controller code relies on this.
+	var n *Notifier
+	require.NoError(t, n.SendEvent(context.Background(), "team.started", map[string]interface{}{"team": "x"}))
+}
+
+func TestSendEvent_PostsEnvelope(t *testing.T) {
+	srv, ch := newTestServer(t)
+	n := NewNotifier(srv.URL, []string{"team.started"})
+	require.NotNil(t, n)
+
+	err := n.SendEvent(context.Background(), "team.started", map[string]interface{}{
+		"team":      "auth-refactor",
+		"namespace": "dev",
+		"data":      map[string]interface{}{"lead": "alice"},
+	})
+	require.NoError(t, err)
+
+	n.inFlight.Wait()
+
+	select {
+	case got := <-ch:
+		assert.Equal(t, "team.started", got["event"])
+		assert.Equal(t, "auth-refactor", got["team"])
+		assert.Equal(t, "dev", got["namespace"])
+		assert.NotEmpty(t, got["timestamp"], "timestamp must be set by notifier")
+		// Timestamp is RFC3339 parseable.
+		_, err := time.Parse(time.RFC3339, got["timestamp"].(string))
+		assert.NoError(t, err, "timestamp must be RFC3339")
+		// Event-specific data round-trips under `data`.
+		data, ok := got["data"].(map[string]interface{})
+		if assert.True(t, ok) {
+			assert.Equal(t, "alice", data["lead"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for webhook POST")
+	}
+}
+
+func TestSendEvent_FiltersUnsubscribedEvents(t *testing.T) {
+	srv, ch := newTestServer(t)
+	n := NewNotifier(srv.URL, []string{"team.completed"})
+
+	// team.started is not in the subscription list.
+	require.NoError(t, n.SendEvent(context.Background(), "team.started", map[string]interface{}{"team": "x"}))
+	n.inFlight.Wait()
+
+	select {
+	case got := <-ch:
+		t.Fatalf("unexpected POST for unsubscribed event: %v", got)
+	case <-time.After(100 * time.Millisecond):
+		// Expected — no delivery.
+	}
+
+	// A subscribed event still fires.
+	require.NoError(t, n.SendEvent(context.Background(), "team.completed", map[string]interface{}{"team": "x"}))
+	n.inFlight.Wait()
+	select {
+	case got := <-ch:
+		assert.Equal(t, "team.completed", got["event"])
+	case <-time.After(2 * time.Second):
+		t.Fatal("subscribed event did not fire")
+	}
+}
+
+func TestSendEvent_IsNonBlocking(t *testing.T) {
+	// A slow webhook must not stall the caller. Stand up a server that sleeps
+	// for longer than a reasonable reconcile and verify SendEvent returns
+	// immediately.
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(3 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(slow.Close)
+
+	n := NewNotifier(slow.URL, []string{"team.started"})
+	start := time.Now()
+	require.NoError(t, n.SendEvent(context.Background(), "team.started", map[string]interface{}{"team": "x"}))
+	elapsed := time.Since(start)
+	assert.Less(t, elapsed, 100*time.Millisecond, "SendEvent returned in %v; must not block on slow webhook", elapsed)
+}
+
+func TestSendEvent_SlowWebhookTimesOut(t *testing.T) {
+	// Background delivery bounds each POST by DefaultTimeout. A hang longer
+	// than that must terminate without leaking the goroutine indefinitely —
+	// inFlight.Wait() proves the goroutine exits.
+	hang := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(DefaultTimeout + 2*time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(hang.Close)
+
+	n := NewNotifier(hang.URL, []string{"team.started"})
+	require.NoError(t, n.SendEvent(context.Background(), "team.started", map[string]interface{}{"team": "x"}))
+
+	done := make(chan struct{})
+	go func() { n.inFlight.Wait(); close(done) }()
+	select {
+	case <-done:
+		// Good — goroutine exited via timeout rather than waiting on the server.
+	case <-time.After(DefaultTimeout + 3*time.Second):
+		t.Fatal("background goroutine did not exit after webhook timeout")
+	}
+}
+
+func TestSendEvent_ServerErrorsAreLoggedNotReturned(t *testing.T) {
+	// Non-2xx responses are not programmer errors; they're log-worthy but must
+	// not propagate back to the reconciler as errors.
+	fail := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(fail.Close)
+
+	n := NewNotifier(fail.URL, []string{"team.started"})
+	require.NoError(t, n.SendEvent(context.Background(), "team.started", map[string]interface{}{"team": "x"}))
+	n.inFlight.Wait()
+}
+
+func TestSendEvent_ConcurrentDeliveries(t *testing.T) {
+	// Multiple events in flight must all arrive. Exercises the inFlight
+	// WaitGroup under load.
+	var count int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&count, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	n := NewNotifier(srv.URL, []string{"team.started"})
+	const N = 20
+	for i := 0; i < N; i++ {
+		require.NoError(t, n.SendEvent(context.Background(), "team.started", map[string]interface{}{"team": "x"}))
+	}
+	n.inFlight.Wait()
+	assert.Equal(t, int32(N), atomic.LoadInt32(&count), "all concurrent POSTs should arrive")
+}
+
+func TestSendEvent_ContentTypeIsJSON(t *testing.T) {
+	ct := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ct <- r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	n := NewNotifier(srv.URL, []string{"team.started"})
+	require.NoError(t, n.SendEvent(context.Background(), "team.started", map[string]interface{}{"team": "x"}))
+	n.inFlight.Wait()
+
+	select {
+	case got := <-ct:
+		assert.Equal(t, "application/json", got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("no request received")
+	}
+}
+
+func TestSendEvent_UnmarshalableDataReturnsError(t *testing.T) {
+	srv, _ := newTestServer(t)
+	n := NewNotifier(srv.URL, []string{"team.started"})
+
+	// A channel cannot be marshaled to JSON — this is a synchronous error.
+	err := n.SendEvent(context.Background(), "team.started", map[string]interface{}{
+		"bad": make(chan int),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "marshal")
+}


### PR DESCRIPTION
Closes #11.

## Summary
- Implements `internal/webhook/Notifier` with the signatures specified in `internal/webhook/doc.go`. POSTs JSON envelopes `{event, team, namespace, timestamp, data}` to a per-team webhook URL from `AgentTeam.spec.observability.webhook`.
- Delivery is **non-blocking** — each POST runs in a background goroutine bounded by a 5s timeout so a slow webhook cannot stall the reconciler.
- Three events wired from the controller: `team.started`, `budget.warning` (at 80% of configured limit, deduped via a `BudgetWarningSent` condition so it fires exactly once), and `teammate.error` (one per failed pod, at the team's transition into `Failed`).

## Event wiring

| Event | Fires from | Dedup mechanism |
|---|---|---|
| `team.started` | `reconcileInitializing` → `Running` transition | Phase transition is itself one-shot |
| `budget.warning` | `reconcileRunning` when cost ≥ 80% of budget | `BudgetWarningSent` Condition persisted on the CR |
| `teammate.error` | `reconcileRunning` when `anyFailed` is detected, one call per failed pod | Fires at the `Running` → `Failed` transition, which only happens once |

## Design notes
- **Nil-safe** — `NewNotifier(\"\", ...)` returns `nil`, and `(*Notifier)(nil).SendEvent(...)` is a no-op. Controller call sites don't need guards.
- **Event filtering** — the subscribed event list in `WebhookSpec.events` is a set; unsubscribed event types are dropped inside `SendEvent` before any HTTP work happens.
- **Synchronous errors only for programmer bugs** — an unmarshalable payload returns an error; delivery failures are logged, not returned, so a flaky webhook never fails a reconcile.
- **Condition-based dedup for `budget.warning`** — survives operator restarts. `kubectl describe agentteam` shows when the warning fired.

## Test plan
- [x] `go test ./internal/webhook/...` — 10 tests covering envelope shape, filtering, non-blocking behavior under slow/hanging servers, timeout bounding, concurrent deliveries, Content-Type, and marshal errors
- [x] `go test ./internal/controller/... -run Webhook` — 5 wiring tests proving each event fires on the correct phase transition, dedup holds, and unsubscribed events stay silent
- [x] `go test ./...` — full suite passes
- [x] `go vet ./...` + `make manifests generate && git diff --exit-code config/ api/ charts/.../crds/` — clean

## Follow-ups (not in this PR)
The other 7 event types in `doc.go` (`team.running`, `task.completed`, `teammate.idle`, `budget.exceeded`, `team.completed`, `team.failed`, `team.timedout`) are defined by the `Notifier` and can be fired from the appropriate reconciler paths in follow-up PRs — the infrastructure is ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)