### PR TITLE
feat(budget): extract cost estimation into internal/budget package (#10)

### DIFF
--- a/internal/budget/tracker.go
+++ b/internal/budget/tracker.go
@@ -1,0 +1,112 @@
+package budget
+
+import "sync"
+
+// Cost rates for April 2026, sourced from doc.go. Rates are USD per million
+// tokens, split between input and output as billed by the Anthropic API.
+const (
+	opusInputPerMillion    = 5.0
+	opusOutputPerMillion   = 25.0
+	sonnetInputPerMillion  = 3.0
+	sonnetOutputPerMillion = 15.0
+)
+
+// Session heuristic: ~50K input + ~5K output tokens per minute of active
+// session. These numbers are deliberately rough — real usage varies heavily
+// by task — but they let the operator produce cost estimates without a
+// feedback channel from Claude Code itself.
+const (
+	inputTokensPerMinute  int64 = 50_000
+	outputTokensPerMinute int64 = 5_000
+	totalTokensPerMinute        = inputTokensPerMinute + outputTokensPerMinute
+
+	modelOpus   = "opus"
+	modelSonnet = "sonnet"
+)
+
+type costRate struct {
+	inputPerMillion, outputPerMillion float64
+}
+
+func rateFor(model string) costRate {
+	switch model {
+	case modelOpus:
+		return costRate{inputPerMillion: opusInputPerMillion, outputPerMillion: opusOutputPerMillion}
+	default:
+		// Sonnet is the fallback for any unrecognized model so operators get a
+		// conservative estimate rather than a zero.
+		return costRate{inputPerMillion: sonnetInputPerMillion, outputPerMillion: sonnetOutputPerMillion}
+	}
+}
+
+// EstimateTokens returns the estimated total (input + output) tokens for a
+// session of the given duration. Non-positive durations return 0. The model
+// argument is accepted for API symmetry with EstimateCost; the heuristic is
+// model-agnostic.
+func EstimateTokens(model string, durationSeconds int64) int64 {
+	_ = model
+	if durationSeconds <= 0 {
+		return 0
+	}
+	return totalTokensPerMinute * durationSeconds / 60
+}
+
+// EstimateCost returns the USD cost for explicit input and output token counts
+// at the given model's rates. Unknown models fall back to Sonnet pricing.
+func EstimateCost(model string, inputTokens, outputTokens int64) float64 {
+	r := rateFor(model)
+	return float64(inputTokens)/1_000_000*r.inputPerMillion +
+		float64(outputTokens)/1_000_000*r.outputPerMillion
+}
+
+// Tracker accumulates session costs across agents in a team and compares the
+// running total against a configured budget limit. Tracker is safe for
+// concurrent use.
+type Tracker struct {
+	mu          sync.Mutex
+	budgetLimit float64
+	totalCost   float64
+}
+
+// NewTracker returns a Tracker with the given USD budget limit. A limit of
+// zero (or negative) disables the over-budget check — IsOverBudget always
+// returns false.
+func NewTracker(budgetLimit float64) *Tracker {
+	return &Tracker{budgetLimit: budgetLimit}
+}
+
+// RecordSession adds the estimated cost of a session of the given duration
+// for the named model to the tracker's running total. Non-positive durations
+// are a no-op. Tokens are split between input and output using the
+// 50K/5K-per-minute heuristic.
+func (t *Tracker) RecordSession(model string, durationSeconds int64) {
+	if durationSeconds <= 0 {
+		return
+	}
+	input := inputTokensPerMinute * durationSeconds / 60
+	output := outputTokensPerMinute * durationSeconds / 60
+	cost := EstimateCost(model, input, output)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.totalCost += cost
+}
+
+// GetTotalCost returns the accumulated USD cost across all recorded sessions.
+func (t *Tracker) GetTotalCost() float64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.totalCost
+}
+
+// IsOverBudget reports whether the accumulated cost has reached or exceeded
+// the configured budget limit. Returns false when no budget is configured
+// (limit <= 0).
+func (t *Tracker) IsOverBudget() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.budgetLimit <= 0 {
+		return false
+	}
+	return t.totalCost >= t.budgetLimit
+}

--- a/internal/budget/tracker_test.go
+++ b/internal/budget/tracker_test.go
@@ -1,0 +1,151 @@
+package budget
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEstimateTokens_ZeroForNonPositiveDuration(t *testing.T) {
+	assert.Equal(t, int64(0), EstimateTokens("opus", 0))
+	assert.Equal(t, int64(0), EstimateTokens("opus", -30))
+}
+
+func TestEstimateTokens_OneMinuteMatchesHeuristic(t *testing.T) {
+	// 50K input + 5K output = 55K total per minute per doc.go.
+	got := EstimateTokens("opus", 60)
+	assert.Equal(t, int64(55_000), got)
+}
+
+func TestEstimateTokens_ModelAgnostic(t *testing.T) {
+	// The heuristic itself does not depend on model — token counts are the
+	// same for opus and sonnet. Only cost differs.
+	opus := EstimateTokens("opus", 600)
+	sonnet := EstimateTokens("sonnet", 600)
+	assert.Equal(t, opus, sonnet)
+}
+
+func TestEstimateCost_OpusRates(t *testing.T) {
+	// 1M input @ $5/M + 1M output @ $25/M = $30.
+	got := EstimateCost("opus", 1_000_000, 1_000_000)
+	assert.InDelta(t, 30.0, got, 0.001)
+}
+
+func TestEstimateCost_SonnetRates(t *testing.T) {
+	// 1M input @ $3/M + 1M output @ $15/M = $18.
+	got := EstimateCost("sonnet", 1_000_000, 1_000_000)
+	assert.InDelta(t, 18.0, got, 0.001)
+}
+
+func TestEstimateCost_UnknownModelFallsBackToSonnet(t *testing.T) {
+	// Any non-opus model bills at Sonnet rates so operators get a
+	// conservative estimate.
+	unknown := EstimateCost("haiku-ish-future-model", 1_000_000, 1_000_000)
+	sonnet := EstimateCost("sonnet", 1_000_000, 1_000_000)
+	assert.Equal(t, sonnet, unknown)
+}
+
+func TestEstimateCost_ZeroTokensZeroCost(t *testing.T) {
+	assert.Equal(t, 0.0, EstimateCost("opus", 0, 0))
+}
+
+func TestTracker_RecordSessionAccumulates(t *testing.T) {
+	tr := NewTracker(0)
+	tr.RecordSession("opus", 60)
+	first := tr.GetTotalCost()
+
+	tr.RecordSession("opus", 60)
+	second := tr.GetTotalCost()
+
+	// Two one-minute opus sessions cost twice one one-minute session.
+	assert.InDelta(t, first*2, second, 0.0001)
+}
+
+func TestTracker_RecordSessionOpusOneMinute(t *testing.T) {
+	// Sanity check on the headline cost figure used in demos.
+	// Opus: 50K input @ $5/M + 5K output @ $25/M = $0.25 + $0.125 = $0.375 per minute.
+	tr := NewTracker(0)
+	tr.RecordSession("opus", 60)
+	assert.InDelta(t, 0.375, tr.GetTotalCost(), 0.001)
+}
+
+func TestTracker_RecordSessionSonnetOneMinute(t *testing.T) {
+	// Sonnet: 50K input @ $3/M + 5K output @ $15/M = $0.15 + $0.075 = $0.225 per minute.
+	tr := NewTracker(0)
+	tr.RecordSession("sonnet", 60)
+	assert.InDelta(t, 0.225, tr.GetTotalCost(), 0.001)
+}
+
+func TestTracker_RecordSessionNonPositiveIsNoOp(t *testing.T) {
+	tr := NewTracker(0)
+	tr.RecordSession("opus", 0)
+	tr.RecordSession("opus", -10)
+	assert.Equal(t, 0.0, tr.GetTotalCost())
+}
+
+func TestTracker_IsOverBudget_UnderLimit(t *testing.T) {
+	tr := NewTracker(100.0)
+	tr.RecordSession("opus", 60) // $0.375
+	assert.False(t, tr.IsOverBudget())
+}
+
+func TestTracker_IsOverBudget_EqualsLimit(t *testing.T) {
+	// Boundary: exactly at the limit is over-budget (>=), matching the
+	// existing isBudgetExceeded semantics in the reconciler.
+	tr := NewTracker(0.375)
+	tr.RecordSession("opus", 60)
+	assert.True(t, tr.IsOverBudget())
+}
+
+func TestTracker_IsOverBudget_AboveLimit(t *testing.T) {
+	tr := NewTracker(0.10)
+	tr.RecordSession("opus", 60) // $0.375 > $0.10
+	assert.True(t, tr.IsOverBudget())
+}
+
+func TestTracker_IsOverBudget_NoLimitMeansNeverOver(t *testing.T) {
+	// Zero (or negative) budget limit disables the check — without this,
+	// teams declared without a budget would always trip the over-budget
+	// path on the first cost above zero.
+	tr := NewTracker(0)
+	tr.RecordSession("opus", 6000) // $37.50 accumulated
+	assert.False(t, tr.IsOverBudget())
+
+	tr2 := NewTracker(-1)
+	tr2.RecordSession("opus", 60)
+	assert.False(t, tr2.IsOverBudget())
+}
+
+func TestTracker_OpusMoreExpensiveThanSonnet(t *testing.T) {
+	opus := NewTracker(0)
+	sonnet := NewTracker(0)
+	opus.RecordSession("opus", 600)
+	sonnet.RecordSession("sonnet", 600)
+	assert.Greater(t, opus.GetTotalCost(), sonnet.GetTotalCost())
+}
+
+func TestTracker_ConcurrentRecordSession(t *testing.T) {
+	// Tracker is documented as safe for concurrent use; race detector would
+	// catch missing locks.
+	tr := NewTracker(0)
+	const (
+		goroutines = 50
+		perG       = 10
+	)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perG; j++ {
+				tr.RecordSession("opus", 60)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Each call adds $0.375; 500 calls total.
+	expected := 0.375 * float64(goroutines*perG)
+	assert.InDelta(t, expected, tr.GetTotalCost(), 0.01)
+}

--- a/internal/controller/agentteam_controller.go
+++ b/internal/controller/agentteam_controller.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	claudev1alpha1 "github.com/amcheste/claude-teams-operator/api/v1alpha1"
+	"github.com/amcheste/claude-teams-operator/internal/budget"
 	"github.com/amcheste/claude-teams-operator/internal/metrics"
 	"github.com/amcheste/claude-teams-operator/internal/webhook"
 )
@@ -518,11 +519,11 @@ func (r *AgentTeamReconciler) maybeFireBudgetWarning(ctx context.Context, team *
 	if budgetWarningSent(team) {
 		return
 	}
-	var limit, current float64
+	var limit float64
 	if _, err := fmt.Sscanf(*team.Spec.Lifecycle.BudgetLimit, "%f", &limit); err != nil || limit <= 0 {
 		return
 	}
-	fmt.Sscanf(team.Status.EstimatedCost, "%f", &current) //nolint:errcheck
+	current := newTeamTracker(team).GetTotalCost()
 	if current < 0.8*limit {
 		return
 	}
@@ -538,8 +539,8 @@ func (r *AgentTeamReconciler) maybeFireBudgetWarning(ctx context.Context, team *
 // budget to Prometheus. Called on each reconcileRunning pass after the cost
 // estimate has been updated.
 func (r *AgentTeamReconciler) exportBudgetMetrics(team *claudev1alpha1.AgentTeam) {
-	var current float64
-	fmt.Sscanf(team.Status.EstimatedCost, "%f", &current) //nolint:errcheck
+	tracker := newTeamTracker(team)
+	current := tracker.GetTotalCost()
 	metrics.RecordCost(team.Name, team.Namespace, current)
 
 	if team.Spec.Lifecycle == nil || team.Spec.Lifecycle.BudgetLimit == nil {
@@ -1260,35 +1261,36 @@ func (r *AgentTeamReconciler) isBudgetExceeded(team *claudev1alpha1.AgentTeam) b
 	if team.Spec.Lifecycle == nil || team.Spec.Lifecycle.BudgetLimit == nil {
 		return false
 	}
-	var limit, current float64
-	if _, err := fmt.Sscanf(*team.Spec.Lifecycle.BudgetLimit, "%f", &limit); err != nil {
-		return false
-	}
-	fmt.Sscanf(team.Status.EstimatedCost, "%f", &current) //nolint:errcheck
-	return current >= limit
+	return newTeamTracker(team).IsOverBudget()
 }
 
-// estimateCost returns a rough USD estimate based on elapsed time and model type.
-// Assumes ~1500 tokens/min for opus ($15/M), ~3000 tokens/min for sonnet ($3/M).
+// estimateCost returns the team's current USD cost estimate, formatted for
+// Status.EstimatedCost display. Delegates to the budget package so rates and
+// heuristics live in one place.
 func estimateCost(team *claudev1alpha1.AgentTeam) string {
-	if team.Status.StartedAt == nil {
-		return "0.00"
-	}
-	elapsed := time.Since(team.Status.StartedAt.Time).Minutes()
-	total := estimateModelCost(team.Spec.Lead.Model, elapsed)
-	for _, tm := range team.Spec.Teammates {
-		total += estimateModelCost(tm.Model, elapsed)
-	}
-	return fmt.Sprintf("%.2f", total)
+	return fmt.Sprintf("%.2f", newTeamTracker(team).GetTotalCost())
 }
 
-func estimateModelCost(model string, elapsedMinutes float64) float64 {
-	switch model {
-	case "opus":
-		return elapsedMinutes * 1500 / 1_000_000 * 15
-	default:
-		return elapsedMinutes * 3000 / 1_000_000 * 3
+// newTeamTracker builds a budget Tracker seeded with one session per agent
+// (lead + teammates) covering the wall-clock time elapsed since the team
+// started. The tracker's limit comes from Spec.Lifecycle.BudgetLimit so a
+// single tracker can answer both "how much has been spent" and "are we
+// over-budget" without a second parse of the limit string.
+func newTeamTracker(team *claudev1alpha1.AgentTeam) *budget.Tracker {
+	var limit float64
+	if team.Spec.Lifecycle != nil && team.Spec.Lifecycle.BudgetLimit != nil {
+		fmt.Sscanf(*team.Spec.Lifecycle.BudgetLimit, "%f", &limit) //nolint:errcheck
 	}
+	tracker := budget.NewTracker(limit)
+	if team.Status.StartedAt == nil {
+		return tracker
+	}
+	elapsedSec := int64(time.Since(team.Status.StartedAt.Time).Seconds())
+	tracker.RecordSession(team.Spec.Lead.Model, elapsedSec)
+	for _, tm := range team.Spec.Teammates {
+		tracker.RecordSession(tm.Model, elapsedSec)
+	}
+	return tracker
 }
 
 // --- Pod Cleanup ---

--- a/internal/controller/agentteam_controller_test.go
+++ b/internal/controller/agentteam_controller_test.go
@@ -592,7 +592,10 @@ func TestIsBudgetExceeded_OverBudget(t *testing.T) {
 	budget := "1.00"
 	team := minimalTeam("b")
 	team.Spec.Lifecycle = &claudev1alpha1.LifecycleSpec{BudgetLimit: &budget}
-	team.Status.EstimatedCost = "1.50"
+	// Team total under the budget package heuristic is $0.60/min (opus +
+	// sonnet). 3 minutes elapsed → $1.80, comfortably over the $1.00 limit.
+	start := metav1.NewTime(time.Now().Add(-3 * time.Minute))
+	team.Status.StartedAt = &start
 	assert.True(t, newReconciler(team).isBudgetExceeded(team))
 }
 

--- a/internal/controller/agentteam_webhook_test.go
+++ b/internal/controller/agentteam_webhook_test.go
@@ -86,13 +86,13 @@ func TestReconcileInitializing_FiresTeamStartedWebhook(t *testing.T) {
 func TestReconcileRunning_FiresBudgetWarningAt80Percent(t *testing.T) {
 	url, events := webhookCaptureServer(t)
 
-	// estimateCost for minimalTeam (opus lead + sonnet worker) is ~$0.0315/min.
-	// At 5h elapsed that's ~$9.45 — 94.5% of a $10 budget, safely in the
-	// [80%, 100%) window so warning fires without the exceeded branch
-	// pre-empting the reconcile.
+	// Under the budget package heuristic, minimalTeam (opus lead + sonnet
+	// worker) runs at $0.60/min. At 15m elapsed that's $9.00 — 90% of a $10
+	// budget, safely in the [80%, 100%) window so the warning fires without
+	// the exceeded branch pre-empting the reconcile.
 	team := withWebhook(withLifecycle(minimalTeam("wh-budget"), "24h", "10.00"), url, []string{"budget.warning"})
 	team.Status.Phase = "Running"
-	start := metav1.NewTime(time.Now().Add(-5 * time.Hour))
+	start := metav1.NewTime(time.Now().Add(-15 * time.Minute))
 	team.Status.StartedAt = &start
 
 	r := newReconciler(team)
@@ -118,7 +118,7 @@ func TestReconcileRunning_BudgetWarningFiresOnlyOnce(t *testing.T) {
 
 	team := withWebhook(withLifecycle(minimalTeam("wh-budget-dedup"), "24h", "10.00"), url, []string{"budget.warning"})
 	team.Status.Phase = "Running"
-	start := metav1.NewTime(time.Now().Add(-5 * time.Hour))
+	start := metav1.NewTime(time.Now().Add(-15 * time.Minute))
 	team.Status.StartedAt = &start
 
 	r := newReconciler(team)


### PR DESCRIPTION
Closes #10.

## Summary
- Implements `internal/budget/Tracker` matching the API spec'd in `doc.go`: `NewTracker`, `EstimateTokens`, `EstimateCost`, `RecordSession`, `GetTotalCost`, `IsOverBudget`.
- Carries the April 2026 rate table (Opus 4.6 at \$5/\$25 per million input/output, Sonnet 4.6 at \$3/\$15) and the session heuristic (~50K input + ~5K output tokens per minute).
- Controller's inline `estimateCost` / `estimateModelCost` / `isBudgetExceeded` are replaced by calls into the new package via a `newTeamTracker` helper that both `exportBudgetMetrics`, `maybeFireBudgetWarning`, and `isBudgetExceeded` share.
- Unknown models fall back to Sonnet rates — conservative estimate rather than a silent zero.

## Rate change (notable)

The new heuristic produces much more realistic cost estimates than the old inline one. For a minimalTeam (opus lead + sonnet worker):

| Heuristic | \$ per minute |
|---|---|
| Old inline (1500 tok/min opus @ \$15/M; 3000 tok/min sonnet @ \$3/M) | \$0.0315 |
| New package (55K tok/min per agent at April 2026 rates) | \$0.60 |

Budget-dependent controller tests are rebased onto the new rates — assertions still track "below / at / over threshold", just against realistic numbers. `TestIsBudgetExceeded_OverBudget` now uses an elapsed time + StartedAt so the tracker computes a real value rather than reading a preset `Status.EstimatedCost` string.

## Test plan
- [x] `go test ./internal/budget/... -race` — 17 tests covering rate correctness (opus/sonnet/unknown), heuristic math, IsOverBudget boundary (`>=`), zero-limit-disables-check, concurrent RecordSession
- [x] `go test ./internal/controller/...` — full controller suite passes; existing budget tests rebased to new rates
- [x] `go test ./...` — all green
- [x] `go vet` + `helm lint` + `make manifests generate` — clean

## v0.3.0 status after this merges

| # | Title | Status |
|---|---|---|
| [#9](https://github.com/amcheste/claude-teams-operator/issues/9) | Prometheus metrics | ✅ |
| [#12](https://github.com/amcheste/claude-teams-operator/issues/12) | ServiceMonitor + Grafana dashboard | ✅ |
| [#11](https://github.com/amcheste/claude-teams-operator/issues/11) | Webhook notification engine | ✅ |
| [#10](https://github.com/amcheste/claude-teams-operator/issues/10) | Budget package extraction | ← this PR |
| [#88](https://github.com/amcheste/claude-teams-operator/issues/88) | Auto-gen CRD reference docs | open |

After this, only #88 (docs hygiene) remains in v0.3.0 — and v0.4.0's crash re-spawn / RBAC work is ready to start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)