### PR TITLE
feat(controller): per-agent ServiceAccounts with scoped RBAC (#14)

### DIFF
--- a/charts/claude-teams-operator/templates/rbac.yaml
+++ b/charts/claude-teams-operator/templates/rbac.yaml
@@ -45,6 +45,14 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
+  # ServiceAccounts (per-agent pod identities)
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Roles + RoleBindings (per-agent RBAC scoping)
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # Jobs (init job for repo clone)
   - apiGroups: ["batch"]
     resources: ["jobs"]

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -10,6 +10,7 @@ rules:
   - configmaps
   - persistentvolumeclaims
   - pods
+  - serviceaccounts
   verbs:
   - create
   - delete
@@ -71,3 +72,16 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/internal/controller/agentteam_controller.go
+++ b/internal/controller/agentteam_controller.go
@@ -11,6 +11,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -104,7 +105,10 @@ func (r *AgentTeamReconciler) initImage() string {
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 
 func (r *AgentTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
@@ -749,6 +753,12 @@ func (r *AgentTeamReconciler) ensureAgentPod(
 		return err
 	}
 
+	// Provision the agent's RBAC (SA + Role + RoleBinding) before the pod so
+	// the kubelet can bind the SA at creation time.
+	if err := r.ensureAgentServiceAccount(ctx, team, agentName); err != nil {
+		return fmt.Errorf("ensuring ServiceAccount for %s: %w", agentName, err)
+	}
+
 	// Create a ConfigMap with the MCP config if this agent has MCP servers.
 	if len(mcpServers) > 0 {
 		if err := r.ensureMCPConfigMap(ctx, team, agentName, mcpServers); err != nil {
@@ -761,6 +771,112 @@ func (r *AgentTeamReconciler) ensureAgentPod(
 		return err
 	}
 	return r.Create(ctx, pod)
+}
+
+// ensureAgentServiceAccount provisions the ServiceAccount, Role, and
+// RoleBinding for a single agent pod. The Role is narrowly scoped — get on
+// the team's API key Secret (restricted to that exact secret name) and
+// get/list/watch on the team's PVCs. A compromised agent pod therefore
+// cannot enumerate cluster resources or reach other teams' secrets.
+//
+// The lead and each teammate get their own SA so per-agent compromise stays
+// contained. This is the core KubeCon RBAC story; it's worth the churn of
+// N resources per team.
+//
+// Safe to call repeatedly — missing resources are created and existing Roles
+// are updated in place if the team's auth secret or PVC set has changed.
+func (r *AgentTeamReconciler) ensureAgentServiceAccount(ctx context.Context, team *claudev1alpha1.AgentTeam, agentName string) error {
+	name := agentServiceAccountName(team, agentName)
+
+	// ServiceAccount.
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: team.Namespace},
+	}
+	if err := ctrl.SetControllerReference(team, sa, r.Scheme); err != nil {
+		return err
+	}
+	if err := r.Create(ctx, sa); err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating ServiceAccount %s: %w", name, err)
+	}
+
+	// Role. Rules are computed from the team's current auth + PVC set so the
+	// Role tracks spec changes.
+	rules := agentPolicyRules(team)
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: team.Namespace},
+		Rules:      rules,
+	}
+	if err := ctrl.SetControllerReference(team, role, r.Scheme); err != nil {
+		return err
+	}
+	existing := &rbacv1.Role{}
+	switch err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: team.Namespace}, existing); {
+	case errors.IsNotFound(err):
+		if err := r.Create(ctx, role); err != nil {
+			return fmt.Errorf("creating Role %s: %w", name, err)
+		}
+	case err != nil:
+		return err
+	default:
+		existing.Rules = rules
+		if err := r.Update(ctx, existing); err != nil {
+			return fmt.Errorf("updating Role %s: %w", name, err)
+		}
+	}
+
+	// RoleBinding.
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: team.Namespace},
+		Subjects: []rbacv1.Subject{
+			{Kind: "ServiceAccount", Name: name, Namespace: team.Namespace},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     name,
+		},
+	}
+	if err := ctrl.SetControllerReference(team, binding, r.Scheme); err != nil {
+		return err
+	}
+	if err := r.Create(ctx, binding); err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating RoleBinding %s: %w", name, err)
+	}
+	return nil
+}
+
+// agentPolicyRules returns the per-agent Role rule set: read the team's API
+// key Secret (by exact name), and read the team's PVCs. Rules are only
+// emitted for resources that actually exist on the team — e.g. an OAuth-only
+// team has no Secret rule.
+func agentPolicyRules(team *claudev1alpha1.AgentTeam) []rbacv1.PolicyRule {
+	var rules []rbacv1.PolicyRule
+
+	secretNames := []string{}
+	if team.Spec.Auth.APIKeySecret != "" {
+		secretNames = append(secretNames, team.Spec.Auth.APIKeySecret)
+	}
+	if team.Spec.Auth.OAuthSecret != "" {
+		secretNames = append(secretNames, team.Spec.Auth.OAuthSecret)
+	}
+	if len(secretNames) > 0 {
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups:     []string{""},
+			Resources:     []string{"secrets"},
+			ResourceNames: secretNames,
+			Verbs:         []string{"get"},
+		})
+	}
+
+	if pvcs := teamPVCNames(team); len(pvcs) > 0 {
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups:     []string{""},
+			Resources:     []string{"persistentvolumeclaims"},
+			ResourceNames: pvcs,
+			Verbs:         []string{"get", "list", "watch"},
+		})
+	}
+	return rules
 }
 
 // ensureMCPConfigMap creates a ConfigMap with the agent's .mcp.json content.
@@ -982,7 +1098,8 @@ func (r *AgentTeamReconciler) buildAgentPod(
 			Labels:    labels,
 		},
 		Spec: corev1.PodSpec{
-			RestartPolicy: corev1.RestartPolicyNever,
+			RestartPolicy:      corev1.RestartPolicyNever,
+			ServiceAccountName: agentServiceAccountName(team, agentName),
 			Containers: []corev1.Container{
 				{
 					Name:         "claude-code",
@@ -1434,6 +1551,32 @@ func agentPodName(team *claudev1alpha1.AgentTeam, agentName string) string {
 
 func agentMCPConfigMapName(team *claudev1alpha1.AgentTeam, agentName string) string {
 	return team.Name + "-" + agentName + "-mcp"
+}
+
+// agentServiceAccountName returns the ServiceAccount name used by an agent pod.
+// Shares the pod's naming convention so `kubectl get sa,pod -l ...` pairs them
+// visually.
+func agentServiceAccountName(team *claudev1alpha1.AgentTeam, agentName string) string {
+	return agentPodName(team, agentName)
+}
+
+// teamPVCNames returns every PVC name an agent pod may mount for the team:
+// the team-state PVC (always), the repo PVC in coding mode, and the output
+// PVC in cowork mode. Order is stable so the Role's resourceNames list
+// does not churn across reconciles.
+func teamPVCNames(team *claudev1alpha1.AgentTeam) []string {
+	names := []string{teamStatePVCName(team)}
+	if team.Spec.Repository != nil && team.Spec.Repository.URL != "" {
+		names = append(names, repoPVCName(team))
+	}
+	if team.Spec.Workspace != nil && team.Spec.Workspace.Output != nil {
+		n := team.Spec.Workspace.Output.PVC
+		if n == "" {
+			n = outputPVCName(team)
+		}
+		names = append(names, n)
+	}
+	return names
 }
 
 func boolPtr(b bool) *bool { return &b }

--- a/internal/controller/agentteam_rbac_test.go
+++ b/internal/controller/agentteam_rbac_test.go
@@ -1,0 +1,234 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestAgentServiceAccountName_MatchesPodName(t *testing.T) {
+	// Sharing a name lets `kubectl get sa,pod -l team=X` pair them visually
+	// and keeps cleanup logic simple (same label selector, same name).
+	team := minimalTeam("sa-name")
+	assert.Equal(t, "sa-name-lead", agentServiceAccountName(team, "lead"))
+	assert.Equal(t, agentPodName(team, "worker"), agentServiceAccountName(team, "worker"))
+}
+
+func TestTeamPVCNames_BaselineOnly(t *testing.T) {
+	team := minimalTeam("pvcs")
+	assert.Equal(t, []string{"pvcs-team-state"}, teamPVCNames(team))
+}
+
+func TestTeamPVCNames_CodingModeIncludesRepo(t *testing.T) {
+	team := withRepo(minimalTeam("pvcs-coding"))
+	assert.Equal(t, []string{"pvcs-coding-team-state", "pvcs-coding-repo"}, teamPVCNames(team))
+}
+
+func TestTeamPVCNames_CoworkModeIncludesOutput(t *testing.T) {
+	team := withWorkspace(minimalTeam("pvcs-cowork"))
+	assert.Equal(t, []string{"pvcs-cowork-team-state", "pvcs-cowork-output"}, teamPVCNames(team))
+}
+
+func TestAgentPolicyRules_APIKeySecret(t *testing.T) {
+	team := minimalTeam("policy")
+	rules := agentPolicyRules(team)
+
+	// Expect exactly one Secret rule with resourceNames restricted to the
+	// team's apiKeySecret (my-secret per minimalTeam) and verbs=[get].
+	var secretRule *rbacv1.PolicyRule
+	for i, rule := range rules {
+		for _, res := range rule.Resources {
+			if res == "secrets" {
+				secretRule = &rules[i]
+			}
+		}
+	}
+	require.NotNil(t, secretRule, "expected a secrets rule")
+	assert.Equal(t, []string{"my-secret"}, secretRule.ResourceNames,
+		"secret rule must restrict to the team's apiKeySecret name")
+	assert.Equal(t, []string{"get"}, secretRule.Verbs)
+}
+
+func TestAgentPolicyRules_OmitsSecretsWhenAuthUnset(t *testing.T) {
+	// An OAuth-less team with a cleared apiKeySecret has no secret rule —
+	// the operator must not grant blanket secret access.
+	team := minimalTeam("no-auth")
+	team.Spec.Auth.APIKeySecret = ""
+	rules := agentPolicyRules(team)
+	for _, rule := range rules {
+		for _, res := range rule.Resources {
+			assert.NotEqual(t, "secrets", res, "no secret rule when auth is unset")
+		}
+	}
+}
+
+func TestAgentPolicyRules_PVCsScopedToTeamOnly(t *testing.T) {
+	team := withRepo(minimalTeam("pvcs-scope"))
+	rules := agentPolicyRules(team)
+	var pvcRule *rbacv1.PolicyRule
+	for i, rule := range rules {
+		for _, res := range rule.Resources {
+			if res == "persistentvolumeclaims" {
+				pvcRule = &rules[i]
+			}
+		}
+	}
+	require.NotNil(t, pvcRule)
+	assert.ElementsMatch(t,
+		[]string{"pvcs-scope-team-state", "pvcs-scope-repo"},
+		pvcRule.ResourceNames,
+		"PVC rule must list only the team's own PVCs")
+}
+
+func TestEnsureAgentServiceAccount_CreatesSARoleAndBinding(t *testing.T) {
+	team := withRepo(minimalTeam("rbac-create"))
+	r := newReconciler(team)
+	team = fetch(t, r, "rbac-create")
+	ctx := context.Background()
+
+	require.NoError(t, r.ensureAgentServiceAccount(ctx, team, "lead"))
+
+	name := "rbac-create-lead"
+
+	var sa corev1.ServiceAccount
+	require.NoError(t, r.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, &sa))
+
+	var role rbacv1.Role
+	require.NoError(t, r.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, &role))
+	// Owner reference back to the team so cascading delete cleans up the Role.
+	require.Len(t, role.OwnerReferences, 1)
+	assert.Equal(t, "rbac-create", role.OwnerReferences[0].Name)
+
+	var rb rbacv1.RoleBinding
+	require.NoError(t, r.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, &rb))
+	require.Len(t, rb.Subjects, 1)
+	assert.Equal(t, "ServiceAccount", rb.Subjects[0].Kind)
+	assert.Equal(t, name, rb.Subjects[0].Name)
+	assert.Equal(t, "Role", rb.RoleRef.Kind)
+	assert.Equal(t, name, rb.RoleRef.Name)
+}
+
+func TestEnsureAgentServiceAccount_Idempotent(t *testing.T) {
+	team := minimalTeam("rbac-idem")
+	r := newReconciler(team)
+	team = fetch(t, r, "rbac-idem")
+	ctx := context.Background()
+
+	require.NoError(t, r.ensureAgentServiceAccount(ctx, team, "lead"))
+	require.NoError(t, r.ensureAgentServiceAccount(ctx, team, "lead"),
+		"second call must not error on pre-existing SA/Role/RoleBinding")
+}
+
+func TestEnsureAgentServiceAccount_UpdatesRoleWhenSecretChanges(t *testing.T) {
+	// If the team rotates its apiKeySecret name, the Role must follow —
+	// otherwise the pod would be granted access to a stale secret.
+	team := minimalTeam("rbac-rotate")
+	r := newReconciler(team)
+	team = fetch(t, r, "rbac-rotate")
+	ctx := context.Background()
+
+	require.NoError(t, r.ensureAgentServiceAccount(ctx, team, "lead"))
+
+	var role rbacv1.Role
+	require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "rbac-rotate-lead", Namespace: "default"}, &role))
+	// Sanity: original secret name is my-secret (minimalTeam default).
+	var secretRule *rbacv1.PolicyRule
+	for i, rule := range role.Rules {
+		for _, res := range rule.Resources {
+			if res == "secrets" {
+				secretRule = &role.Rules[i]
+			}
+		}
+	}
+	require.NotNil(t, secretRule)
+	assert.Equal(t, []string{"my-secret"}, secretRule.ResourceNames)
+
+	// Rotate the secret and re-run.
+	team.Spec.Auth.APIKeySecret = "rotated-secret"
+	require.NoError(t, r.Update(ctx, team))
+	team = fetch(t, r, "rbac-rotate")
+	require.NoError(t, r.ensureAgentServiceAccount(ctx, team, "lead"))
+
+	require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "rbac-rotate-lead", Namespace: "default"}, &role))
+	secretRule = nil
+	for i, rule := range role.Rules {
+		for _, res := range rule.Resources {
+			if res == "secrets" {
+				secretRule = &role.Rules[i]
+			}
+		}
+	}
+	require.NotNil(t, secretRule)
+	assert.Equal(t, []string{"rotated-secret"}, secretRule.ResourceNames)
+}
+
+func TestEnsureAgentPod_SetsServiceAccountName(t *testing.T) {
+	// End-to-end: after ensureAgentPod creates a pod, its spec points at the
+	// per-agent ServiceAccount.
+	team := minimalTeam("sa-pod")
+	r := newReconciler(team)
+	team = fetch(t, r, "sa-pod")
+	ctx := context.Background()
+
+	require.NoError(t, r.ensureAgentPod(ctx, team, "worker", "sonnet", "work",
+		"auto-accept", false, corev1.ResourceRequirements{}, nil, nil, nil))
+
+	var pod corev1.Pod
+	require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "sa-pod-worker", Namespace: "default"}, &pod))
+	assert.Equal(t, "sa-pod-worker", pod.Spec.ServiceAccountName)
+
+	// And the SA actually exists.
+	var sa corev1.ServiceAccount
+	require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "sa-pod-worker", Namespace: "default"}, &sa))
+}
+
+func TestEnsureAgentPod_CreatesDistinctSAPerAgent(t *testing.T) {
+	// Each teammate gets its own SA — the whole point of the feature.
+	team := minimalTeam("distinct-sa")
+	r := newReconciler(team)
+	team = fetch(t, r, "distinct-sa")
+	ctx := context.Background()
+
+	require.NoError(t, r.ensureAgentPod(ctx, team, "lead", "opus", "lead", "auto-accept", true, corev1.ResourceRequirements{}, nil, nil, nil))
+	require.NoError(t, r.ensureAgentPod(ctx, team, "worker", "sonnet", "work", "auto-accept", false, corev1.ResourceRequirements{}, nil, nil, nil))
+
+	var sa1, sa2 corev1.ServiceAccount
+	require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "distinct-sa-lead", Namespace: "default"}, &sa1))
+	require.NoError(t, r.Get(ctx, types.NamespacedName{Name: "distinct-sa-worker", Namespace: "default"}, &sa2))
+	assert.NotEqual(t, sa1.Name, sa2.Name)
+}
+
+func TestEnsureAgentServiceAccount_OwnerRefSetForCascadingDelete(t *testing.T) {
+	// Owner references back to the team so cascading delete cleans up every
+	// per-agent RBAC object when the AgentTeam is deleted.
+	team := minimalTeam("gc-rbac")
+	r := newReconciler(team)
+	team = fetch(t, r, "gc-rbac")
+	ctx := context.Background()
+	require.NoError(t, r.ensureAgentServiceAccount(ctx, team, "lead"))
+
+	name := types.NamespacedName{Name: "gc-rbac-lead", Namespace: "default"}
+
+	var sa corev1.ServiceAccount
+	require.NoError(t, r.Get(ctx, name, &sa))
+	require.Len(t, sa.OwnerReferences, 1)
+	assert.Equal(t, "gc-rbac", sa.OwnerReferences[0].Name)
+
+	var role rbacv1.Role
+	require.NoError(t, r.Get(ctx, name, &role))
+	require.Len(t, role.OwnerReferences, 1)
+	assert.Equal(t, "gc-rbac", role.OwnerReferences[0].Name)
+
+	var rb rbacv1.RoleBinding
+	require.NoError(t, r.Get(ctx, name, &rb))
+	require.Len(t, rb.OwnerReferences, 1)
+	assert.Equal(t, "gc-rbac", rb.OwnerReferences[0].Name)
+}
+
+var _ = errors.IsNotFound


### PR DESCRIPTION
Closes #14.

## Summary
- Every agent pod (lead + each teammate) now runs under its own `ServiceAccount` instead of the operator's cluster-wide SA. A compromised pod cannot enumerate cluster resources or reach other teams' secrets.
- Three new per-agent resources, all owned by the `AgentTeam` (cascading delete) and all namespace-scoped:
  - `ServiceAccount` named `<team>-<agent>` (same name as the pod)
  - `Role` with narrowly-scoped rules (see below)
  - `RoleBinding` tying SA to Role

## Role rules

| Resource | Verbs | `resourceNames` |
|---|---|---|
| `secrets` | `get` | `[apiKeySecret, oauthSecret]` (only the ones actually set) |
| `persistentvolumeclaims` | `get`, `list`, `watch` | the team's own PVCs (team-state, plus repo in coding mode, plus output in cowork mode) |

Rules are computed per-call, so teams that **rotate their `apiKeySecret`** propagate into the Role without a full restart — existing roles are updated in place.

## Integration

`ensureAgentServiceAccount` is called from inside `ensureAgentPod` so every spawn path picks it up: initial deploy, approval-gate-released spawns, and the crash re-spawn path from #13. The pod's `spec.serviceAccountName` points at the new SA.

Operator RBAC (kubebuilder markers + the hand-written Helm `ClusterRole`) is extended with `serviceaccounts`, `roles`, `rolebindings` so the operator can manage what it provisions.

## Test plan
- [x] `go test ./internal/controller/...` — 13 RBAC-specific tests cover naming, PVC enumeration per team mode, scoped `resourceNames` for secrets + PVCs, auth-unset omits the secret rule, idempotent re-entry, Role update on secret rotation, pod gets the correct SA, distinct SA per agent, owner references for cascading delete. Full suite passes.
- [x] `make manifests generate && git diff --exit-code` — the generated `config/rbac/role.yaml` now includes the new resources; Helm chart mirror updated by hand to match.
- [x] `go vet ./...` + `helm lint ./charts/claude-teams-operator` (with and without observability overrides) — clean.

## KubeCon angle

This directly implements the "Per-agent RBAC via ServiceAccounts" talk theme. Live demo: `kubectl auth can-i get secrets/other-team-key --as=system:serviceaccount:default:team-a-reviewer` → **no**. Exactly the security story for the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)