### PR TITLE
feat(controller): implement OnComplete=create-pr via GitHub REST API (#15)

### DIFF
--- a/api/v1alpha1/agentteam_types.go
+++ b/api/v1alpha1/agentteam_types.go
@@ -311,6 +311,20 @@ type LifecycleSpec struct {
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	MaxRestarts *int32 `json:"maxRestarts,omitempty"`
+
+	// GitHubTokenSecret names a Secret in the team's namespace carrying a
+	// GitHub token under the key GITHUB_TOKEN. Used by OnComplete=create-pr
+	// (and OnComplete=push-branch, once implemented) to authenticate against
+	// the GitHub REST API.
+	// +optional
+	GitHubTokenSecret string `json:"githubTokenSecret,omitempty"`
+
+	// PRTitleTemplate overrides the title template used by OnComplete=create-pr.
+	// Available variables: .TeamName, .Namespace. When empty, falls back to
+	// Spec.Lifecycle.PullRequest.TitleTemplate, then to the default
+	// "claude-teams: {{.TeamName}}".
+	// +optional
+	PRTitleTemplate string `json:"prTitleTemplate,omitempty"`
 }
 
 // PullRequestSpec configures automatic PR creation.

--- a/charts/claude-teams-operator/crds/claude.amcheste.io_agentteamruns.yaml
+++ b/charts/claude-teams-operator/crds/claude.amcheste.io_agentteamruns.yaml
@@ -235,6 +235,13 @@ spec:
                     description: BudgetLimit is the maximum API spend in USD before
                       the team is terminated (e.g. "10.00").
                     type: string
+                  githubTokenSecret:
+                    description: |-
+                      GitHubTokenSecret names a Secret in the team's namespace carrying a
+                      GitHub token under the key GITHUB_TOKEN. Used by OnComplete=create-pr
+                      (and OnComplete=push-branch, once implemented) to authenticate against
+                      the GitHub REST API.
+                    type: string
                   maxRestarts:
                     default: 3
                     description: |-
@@ -253,6 +260,13 @@ spec:
                     - push-branch
                     - notify
                     - none
+                    type: string
+                  prTitleTemplate:
+                    description: |-
+                      PRTitleTemplate overrides the title template used by OnComplete=create-pr.
+                      Available variables: .TeamName, .Namespace. When empty, falls back to
+                      Spec.Lifecycle.PullRequest.TitleTemplate, then to the default
+                      "claude-teams: {{.TeamName}}".
                     type: string
                   pullRequest:
                     description: PullRequest configures PR creation when onComplete

--- a/charts/claude-teams-operator/crds/claude.amcheste.io_agentteams.yaml
+++ b/charts/claude-teams-operator/crds/claude.amcheste.io_agentteams.yaml
@@ -280,6 +280,13 @@ spec:
                     description: BudgetLimit is the maximum API spend in USD before
                       the team is terminated (e.g. "10.00").
                     type: string
+                  githubTokenSecret:
+                    description: |-
+                      GitHubTokenSecret names a Secret in the team's namespace carrying a
+                      GitHub token under the key GITHUB_TOKEN. Used by OnComplete=create-pr
+                      (and OnComplete=push-branch, once implemented) to authenticate against
+                      the GitHub REST API.
+                    type: string
                   maxRestarts:
                     default: 3
                     description: |-
@@ -298,6 +305,13 @@ spec:
                     - push-branch
                     - notify
                     - none
+                    type: string
+                  prTitleTemplate:
+                    description: |-
+                      PRTitleTemplate overrides the title template used by OnComplete=create-pr.
+                      Available variables: .TeamName, .Namespace. When empty, falls back to
+                      Spec.Lifecycle.PullRequest.TitleTemplate, then to the default
+                      "claude-teams: {{.TeamName}}".
                     type: string
                   pullRequest:
                     description: PullRequest configures PR creation when onComplete

--- a/charts/claude-teams-operator/crds/claude.amcheste.io_agentteamtemplates.yaml
+++ b/charts/claude-teams-operator/crds/claude.amcheste.io_agentteamtemplates.yaml
@@ -125,6 +125,13 @@ spec:
                     description: BudgetLimit is the maximum API spend in USD before
                       the team is terminated (e.g. "10.00").
                     type: string
+                  githubTokenSecret:
+                    description: |-
+                      GitHubTokenSecret names a Secret in the team's namespace carrying a
+                      GitHub token under the key GITHUB_TOKEN. Used by OnComplete=create-pr
+                      (and OnComplete=push-branch, once implemented) to authenticate against
+                      the GitHub REST API.
+                    type: string
                   maxRestarts:
                     default: 3
                     description: |-
@@ -143,6 +150,13 @@ spec:
                     - push-branch
                     - notify
                     - none
+                    type: string
+                  prTitleTemplate:
+                    description: |-
+                      PRTitleTemplate overrides the title template used by OnComplete=create-pr.
+                      Available variables: .TeamName, .Namespace. When empty, falls back to
+                      Spec.Lifecycle.PullRequest.TitleTemplate, then to the default
+                      "claude-teams: {{.TeamName}}".
                     type: string
                   pullRequest:
                     description: PullRequest configures PR creation when onComplete

--- a/config/crd/bases/claude.amcheste.io_agentteamruns.yaml
+++ b/config/crd/bases/claude.amcheste.io_agentteamruns.yaml
@@ -235,6 +235,13 @@ spec:
                     description: BudgetLimit is the maximum API spend in USD before
                       the team is terminated (e.g. "10.00").
                     type: string
+                  githubTokenSecret:
+                    description: |-
+                      GitHubTokenSecret names a Secret in the team's namespace carrying a
+                      GitHub token under the key GITHUB_TOKEN. Used by OnComplete=create-pr
+                      (and OnComplete=push-branch, once implemented) to authenticate against
+                      the GitHub REST API.
+                    type: string
                   maxRestarts:
                     default: 3
                     description: |-
@@ -253,6 +260,13 @@ spec:
                     - push-branch
                     - notify
                     - none
+                    type: string
+                  prTitleTemplate:
+                    description: |-
+                      PRTitleTemplate overrides the title template used by OnComplete=create-pr.
+                      Available variables: .TeamName, .Namespace. When empty, falls back to
+                      Spec.Lifecycle.PullRequest.TitleTemplate, then to the default
+                      "claude-teams: {{.TeamName}}".
                     type: string
                   pullRequest:
                     description: PullRequest configures PR creation when onComplete

--- a/config/crd/bases/claude.amcheste.io_agentteams.yaml
+++ b/config/crd/bases/claude.amcheste.io_agentteams.yaml
@@ -280,6 +280,13 @@ spec:
                     description: BudgetLimit is the maximum API spend in USD before
                       the team is terminated (e.g. "10.00").
                     type: string
+                  githubTokenSecret:
+                    description: |-
+                      GitHubTokenSecret names a Secret in the team's namespace carrying a
+                      GitHub token under the key GITHUB_TOKEN. Used by OnComplete=create-pr
+                      (and OnComplete=push-branch, once implemented) to authenticate against
+                      the GitHub REST API.
+                    type: string
                   maxRestarts:
                     default: 3
                     description: |-
@@ -298,6 +305,13 @@ spec:
                     - push-branch
                     - notify
                     - none
+                    type: string
+                  prTitleTemplate:
+                    description: |-
+                      PRTitleTemplate overrides the title template used by OnComplete=create-pr.
+                      Available variables: .TeamName, .Namespace. When empty, falls back to
+                      Spec.Lifecycle.PullRequest.TitleTemplate, then to the default
+                      "claude-teams: {{.TeamName}}".
                     type: string
                   pullRequest:
                     description: PullRequest configures PR creation when onComplete

--- a/config/crd/bases/claude.amcheste.io_agentteamtemplates.yaml
+++ b/config/crd/bases/claude.amcheste.io_agentteamtemplates.yaml
@@ -125,6 +125,13 @@ spec:
                     description: BudgetLimit is the maximum API spend in USD before
                       the team is terminated (e.g. "10.00").
                     type: string
+                  githubTokenSecret:
+                    description: |-
+                      GitHubTokenSecret names a Secret in the team's namespace carrying a
+                      GitHub token under the key GITHUB_TOKEN. Used by OnComplete=create-pr
+                      (and OnComplete=push-branch, once implemented) to authenticate against
+                      the GitHub REST API.
+                    type: string
                   maxRestarts:
                     default: 3
                     description: |-
@@ -143,6 +150,13 @@ spec:
                     - push-branch
                     - notify
                     - none
+                    type: string
+                  prTitleTemplate:
+                    description: |-
+                      PRTitleTemplate overrides the title template used by OnComplete=create-pr.
+                      Available variables: .TeamName, .Namespace. When empty, falls back to
+                      Spec.Lifecycle.PullRequest.TitleTemplate, then to the default
+                      "claude-teams: {{.TeamName}}".
                     type: string
                   pullRequest:
                     description: PullRequest configures PR creation when onComplete

--- a/internal/controller/agentteam_controller.go
+++ b/internal/controller/agentteam_controller.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"text/template"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -24,6 +25,7 @@ import (
 
 	claudev1alpha1 "github.com/amcheste/claude-teams-operator/api/v1alpha1"
 	"github.com/amcheste/claude-teams-operator/internal/budget"
+	"github.com/amcheste/claude-teams-operator/internal/github"
 	"github.com/amcheste/claude-teams-operator/internal/metrics"
 	"github.com/amcheste/claude-teams-operator/internal/webhook"
 )
@@ -59,6 +61,12 @@ type AgentTeamReconciler struct {
 	// Defaults to ReadWriteMany (requires NFS/EFS). Set to ReadWriteOnce for
 	// single-node clusters such as Kind where all pods share the same node.
 	PVCAccessMode corev1.PersistentVolumeAccessMode
+
+	// GitHubBaseURL overrides the GitHub REST API base URL used for
+	// OnComplete=create-pr. Empty means production (https://api.github.com).
+	// Primarily a test seam; a production deployment that needs GitHub
+	// Enterprise can set this to the Enterprise API URL.
+	GitHubBaseURL string
 
 	// Recorder emits Kubernetes Events against AgentTeam objects. Populated by
 	// SetupWithManager. Tests may inject a fake recorder directly. The
@@ -1253,11 +1261,182 @@ func (r *AgentTeamReconciler) executeOnComplete(ctx context.Context, team *claud
 			return r.sendWebhookEvent(ctx, team.Spec.Observability.Webhook.URL, "completed", team)
 		}
 	case "create-pr":
-		log.Info("TODO: create PR via gh CLI or GitHub API")
+		if err := r.executeCreatePR(ctx, team); err != nil {
+			log.Error(err, "create-pr failed")
+			r.recordEvent(team, corev1.EventTypeWarning, "PRCreationFailed", err.Error())
+			return err
+		}
 	case "push-branch":
 		log.Info("TODO: push consolidated branch")
 	}
 	return nil
+}
+
+// --- Pull Request Creation ---
+
+const (
+	defaultPRTitleTemplate = "claude-teams: {{.TeamName}}"
+	defaultBaseBranch      = "main"
+)
+
+// executeCreatePR opens a GitHub pull request for a completed coding team.
+// Requires spec.repository.url (to parse owner/repo) and
+// spec.lifecycle.githubTokenSecret (to authenticate). Reviewers and labels
+// from spec.lifecycle.pullRequest are applied best-effort; failures there
+// are logged but do not fail the overall operation — the PR already exists.
+//
+// Writes the created PR's URL and state into status.pullRequest. Safe to
+// call repeatedly; a PR that already exists does not re-trigger the
+// HTTP request because executeOnComplete only runs once per team.
+func (r *AgentTeamReconciler) executeCreatePR(ctx context.Context, team *claudev1alpha1.AgentTeam) error {
+	log := log.FromContext(ctx)
+
+	if team.Spec.Repository == nil || team.Spec.Repository.URL == "" {
+		return fmt.Errorf("create-pr requires spec.repository.url")
+	}
+	if team.Spec.Lifecycle == nil || team.Spec.Lifecycle.GitHubTokenSecret == "" {
+		return fmt.Errorf("create-pr requires spec.lifecycle.githubTokenSecret")
+	}
+
+	owner, repo, err := github.ParseRepo(team.Spec.Repository.URL)
+	if err != nil {
+		return fmt.Errorf("parsing repo URL: %w", err)
+	}
+
+	token, err := r.readGitHubToken(ctx, team)
+	if err != nil {
+		return err
+	}
+
+	title, err := renderPRTitle(team)
+	if err != nil {
+		return fmt.Errorf("rendering PR title: %w", err)
+	}
+	body := buildPRBody(team)
+
+	head, base := prBranches(team)
+	var clientOpts []github.Option
+	if r.GitHubBaseURL != "" {
+		clientOpts = append(clientOpts, github.WithBaseURL(r.GitHubBaseURL))
+	}
+	client := github.NewClient(token, clientOpts...)
+	pr, err := client.CreatePullRequest(ctx, owner, repo, &github.PullRequestRequest{
+		Title: title,
+		Body:  body,
+		Head:  head,
+		Base:  base,
+	})
+	if err != nil {
+		return fmt.Errorf("creating pull request: %w", err)
+	}
+
+	team.Status.PullRequest = &claudev1alpha1.PullRequestStatus{
+		URL:   pr.HTMLURL,
+		State: pr.State,
+	}
+	r.recordEvent(team, corev1.EventTypeNormal, "PullRequestCreated", "Opened PR %s", pr.HTMLURL)
+	log.Info("Pull request created", "url", pr.HTMLURL, "number", pr.Number)
+
+	// Reviewers + labels are nice-to-haves: if the token cannot modify them
+	// (e.g. missing scopes on a read-write-to-pulls-only PAT), the PR is
+	// still useful. Log the error and keep going.
+	if prSpec := team.Spec.Lifecycle.PullRequest; prSpec != nil {
+		if err := client.RequestReviewers(ctx, owner, repo, pr.Number, prSpec.Reviewers); err != nil {
+			log.Error(err, "requesting reviewers", "reviewers", prSpec.Reviewers)
+		}
+		if err := client.AddLabels(ctx, owner, repo, pr.Number, prSpec.Labels); err != nil {
+			log.Error(err, "adding labels", "labels", prSpec.Labels)
+		}
+	}
+	return nil
+}
+
+// readGitHubToken loads the GitHub token from the configured Secret. The
+// Secret must have a key named GITHUB_TOKEN.
+func (r *AgentTeamReconciler) readGitHubToken(ctx context.Context, team *claudev1alpha1.AgentTeam) (string, error) {
+	name := team.Spec.Lifecycle.GitHubTokenSecret
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: team.Namespace}, secret); err != nil {
+		return "", fmt.Errorf("reading GitHub token secret %s: %w", name, err)
+	}
+	token, ok := secret.Data["GITHUB_TOKEN"]
+	if !ok || len(token) == 0 {
+		return "", fmt.Errorf("secret %s is missing key GITHUB_TOKEN", name)
+	}
+	return strings.TrimSpace(string(token)), nil
+}
+
+// renderPRTitle resolves the PR title template. Precedence:
+// Lifecycle.PRTitleTemplate > Lifecycle.PullRequest.TitleTemplate > default.
+func renderPRTitle(team *claudev1alpha1.AgentTeam) (string, error) {
+	tmpl := defaultPRTitleTemplate
+	if team.Spec.Lifecycle != nil {
+		if team.Spec.Lifecycle.PRTitleTemplate != "" {
+			tmpl = team.Spec.Lifecycle.PRTitleTemplate
+		} else if team.Spec.Lifecycle.PullRequest != nil && team.Spec.Lifecycle.PullRequest.TitleTemplate != "" {
+			tmpl = team.Spec.Lifecycle.PullRequest.TitleTemplate
+		}
+	}
+	t, err := template.New("pr-title").Parse(tmpl)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, map[string]string{
+		"TeamName":  team.Name,
+		"Namespace": team.Namespace,
+	}); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(buf.String()), nil
+}
+
+// buildPRBody renders the PR body from the team's status. Lists completed
+// task counts and the list of teammates that contributed.
+func buildPRBody(team *claudev1alpha1.AgentTeam) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Automated pull request from Claude Agent Teams.\n\n")
+	fmt.Fprintf(&b, "**Team:** `%s/%s`\n\n", team.Namespace, team.Name)
+
+	if team.Status.Tasks != nil {
+		fmt.Fprintf(&b, "## Tasks\n\n- Completed: %d\n- Total: %d\n\n",
+			team.Status.Tasks.Completed, team.Status.Tasks.Total)
+	}
+
+	if len(team.Status.Teammates) > 0 {
+		fmt.Fprintf(&b, "## Teammates\n\n")
+		for _, tm := range team.Status.Teammates {
+			fmt.Fprintf(&b, "- `%s` — phase=%s, tasksCompleted=%d, restarts=%d\n",
+				tm.Name, tm.Phase, tm.TasksCompleted, tm.RestartCount)
+		}
+		fmt.Fprintln(&b)
+	}
+
+	if team.Status.EstimatedCost != "" {
+		fmt.Fprintf(&b, "**Estimated cost:** $%s\n\n", team.Status.EstimatedCost)
+	}
+
+	fmt.Fprintln(&b, "---")
+	fmt.Fprintln(&b, "Generated by [claude-teams-operator](https://github.com/amcheste/claude-teams-operator).")
+	return b.String()
+}
+
+// prBranches returns the head and base branches for the PR. Head defaults to
+// spec.repository.branch (the branch the agents worked on); base defaults to
+// spec.lifecycle.pullRequest.targetBranch, then "main".
+func prBranches(team *claudev1alpha1.AgentTeam) (head, base string) {
+	head = ""
+	if team.Spec.Repository != nil {
+		head = team.Spec.Repository.Branch
+	}
+	if head == "" {
+		head = defaultBaseBranch
+	}
+	base = defaultBaseBranch
+	if team.Spec.Lifecycle != nil && team.Spec.Lifecycle.PullRequest != nil && team.Spec.Lifecycle.PullRequest.TargetBranch != "" {
+		base = team.Spec.Lifecycle.PullRequest.TargetBranch
+	}
+	return head, base
 }
 
 // --- Approval Gates ---

--- a/internal/controller/agentteam_controller_test.go
+++ b/internal/controller/agentteam_controller_test.go
@@ -1560,16 +1560,18 @@ func TestExecuteOnComplete_NotifyWithoutObservability_NoOp(t *testing.T) {
 		"OnComplete=notify with no Observability must be a silent no-op")
 }
 
-// TestExecuteOnComplete_CreatePR_StubReturnsNil covers the "create-pr" log-only
-// stub. Until #4/#7 land the real implementation, this branch must just log
-// and return nil so the team still finishes cleanly.
-func TestExecuteOnComplete_CreatePR_StubReturnsNil(t *testing.T) {
+// TestExecuteOnComplete_CreatePR_MissingRepoErrors — a team configured with
+// OnComplete=create-pr but no repository URL must surface the configuration
+// error. The reconcileRunning caller swallows the error so the team still
+// finishes, but the operator logs it and emits a PRCreationFailed event.
+func TestExecuteOnComplete_CreatePR_MissingRepoErrors(t *testing.T) {
 	team := minimalTeam("create-pr-team")
 	team.Spec.Lifecycle = &claudev1alpha1.LifecycleSpec{OnComplete: "create-pr"}
 
 	r := newReconciler(team)
-	assert.NoError(t, r.executeOnComplete(context.Background(), team),
-		"create-pr stub must return nil so completion isn't blocked")
+	err := r.executeOnComplete(context.Background(), team)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "repository.url")
 }
 
 // TestExecuteOnComplete_PushBranch_StubReturnsNil covers the "push-branch"

--- a/internal/controller/agentteam_createpr_test.go
+++ b/internal/controller/agentteam_createpr_test.go
@@ -1,0 +1,288 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	claudev1alpha1 "github.com/amcheste/claude-teams-operator/api/v1alpha1"
+	"github.com/amcheste/claude-teams-operator/internal/github"
+)
+
+// githubCaptureServer stands up a fake GitHub API capturing each request's
+// path, method, body (parsed as PullRequestRequest), and any reviewer/label
+// calls. Returns a stable PR response so tests can assert the status update.
+type capturedRequest struct {
+	method string
+	path   string
+	body   []byte
+}
+
+func githubCaptureServer(t *testing.T) (url string, reqs *[]capturedRequest) {
+	t.Helper()
+	list := []capturedRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		list = append(list, capturedRequest{method: r.Method, path: r.URL.Path, body: body})
+		if strings.HasSuffix(r.URL.Path, "/pulls") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"number":99,"html_url":"https://github.com/acme/repo/pull/99","state":"open"}`))
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL, &list
+}
+
+// withCreatePR is a test helper that configures a team for OnComplete=create-pr
+// and seeds the referenced GitHub token Secret in the fake client.
+func withCreatePR(t *testing.T, team *claudev1alpha1.AgentTeam, repoURL, secretName string, reviewers, labels []string) {
+	t.Helper()
+	team.Spec.Repository = &claudev1alpha1.RepositorySpec{
+		URL:    repoURL,
+		Branch: "feature-branch",
+	}
+	team.Spec.Lifecycle = &claudev1alpha1.LifecycleSpec{
+		OnComplete:        "create-pr",
+		GitHubTokenSecret: secretName,
+		PullRequest: &claudev1alpha1.PullRequestSpec{
+			TargetBranch: "main",
+			Reviewers:    reviewers,
+			Labels:       labels,
+		},
+	}
+}
+
+// TestExecuteCreatePR_HappyPath — seeded secret + reachable API → PR is
+// created, reviewers requested, labels added, status.PullRequest populated.
+//
+// The controller calls the real GitHub REST API via a *github.Client built
+// inside executeCreatePR. To redirect to the httptest server we monkey-patch
+// the default base URL via the github package's DefaultBaseURL constant —
+// test-only since the constant is package-scoped.
+func TestExecuteCreatePR_HappyPath(t *testing.T) {
+	apiURL, reqs := githubCaptureServer(t)
+
+	// Build the team + token secret.
+	team := minimalTeam("ship-it")
+	withCreatePR(t, team, "https://github.com/acme/repo.git", "gh-token", []string{"alice"}, []string{"ai"})
+
+	token := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "gh-token", Namespace: "default"},
+		Data:       map[string][]byte{"GITHUB_TOKEN": []byte("ghp_test_secret")},
+	}
+
+	r := newReconciler(team, token)
+	r.GitHubBaseURL = apiURL
+	team = fetch(t, r, "ship-it")
+
+	err := r.executeCreatePR(context.Background(), team)
+	require.NoError(t, err)
+
+	// Status populated.
+	require.NotNil(t, team.Status.PullRequest)
+	assert.Equal(t, "https://github.com/acme/repo/pull/99", team.Status.PullRequest.URL)
+	assert.Equal(t, "open", team.Status.PullRequest.State)
+
+	// Three API calls: create PR, request reviewers, add labels.
+	paths := []string{}
+	for _, r := range *reqs {
+		paths = append(paths, r.path)
+	}
+	assert.Contains(t, paths, "/repos/acme/repo/pulls")
+	assert.Contains(t, paths, "/repos/acme/repo/pulls/99/requested_reviewers")
+	assert.Contains(t, paths, "/repos/acme/repo/issues/99/labels")
+
+	// PR request body carries the templated title, head, and base.
+	var prBody github.PullRequestRequest
+	for _, req := range *reqs {
+		if req.path == "/repos/acme/repo/pulls" {
+			require.NoError(t, json.Unmarshal(req.body, &prBody))
+		}
+	}
+	assert.Contains(t, prBody.Title, "ship-it", "title must reference the team name")
+	assert.Equal(t, "feature-branch", prBody.Head)
+	assert.Equal(t, "main", prBody.Base)
+	assert.Contains(t, prBody.Body, "ship-it", "body must carry team context")
+}
+
+func TestExecuteCreatePR_MissingTokenSecretErrors(t *testing.T) {
+	team := minimalTeam("no-token")
+	withCreatePR(t, team, "https://github.com/acme/repo", "missing-secret", nil, nil)
+
+	r := newReconciler(team)
+	team = fetch(t, r, "no-token")
+
+	err := r.executeCreatePR(context.Background(), team)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing-secret")
+}
+
+func TestExecuteCreatePR_SecretWithoutTokenKeyErrors(t *testing.T) {
+	// Secret exists but lacks the GITHUB_TOKEN key — treat as misconfigured,
+	// not as "no token at all".
+	team := minimalTeam("empty-key")
+	withCreatePR(t, team, "https://github.com/acme/repo", "empty", nil, nil)
+
+	badSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "empty", Namespace: "default"},
+		Data:       map[string][]byte{"WRONG_KEY": []byte("x")},
+	}
+	r := newReconciler(team, badSecret)
+	team = fetch(t, r, "empty-key")
+
+	err := r.executeCreatePR(context.Background(), team)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GITHUB_TOKEN")
+}
+
+func TestExecuteCreatePR_APIErrorSurfacesInErrorMessage(t *testing.T) {
+	// 422 Validation Failed — the operator must bubble GitHub's message up
+	// so kubectl describe shows why the PR didn't open.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"message":"Validation Failed","errors":[{"field":"head","code":"invalid"}]}`))
+	}))
+	defer srv.Close()
+
+	team := minimalTeam("bad-head")
+	withCreatePR(t, team, "https://github.com/acme/repo", "gh-token", nil, nil)
+	token := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "gh-token", Namespace: "default"},
+		Data:       map[string][]byte{"GITHUB_TOKEN": []byte("ghp_test_secret")},
+	}
+	r := newReconciler(team, token)
+	r.GitHubBaseURL = srv.URL
+	team = fetch(t, r, "bad-head")
+
+	err := r.executeCreatePR(context.Background(), team)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "422")
+	assert.Contains(t, err.Error(), "Validation Failed")
+}
+
+func TestExecuteCreatePR_SkipsReviewerAndLabelFailures(t *testing.T) {
+	// Reviewer/label calls failing must not fail the overall operation — the
+	// PR already exists and is the primary deliverable. Simulate this by
+	// returning 200 for the PR and 403 for the follow-up calls.
+	var prCreated bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/pulls") {
+			prCreated = true
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"number":7,"html_url":"https://github.com/a/b/pull/7","state":"open"}`))
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"Resource not accessible"}`))
+	}))
+	defer srv.Close()
+
+	team := minimalTeam("partial-perm")
+	withCreatePR(t, team, "https://github.com/a/b", "gh-token", []string{"alice"}, []string{"ai"})
+	token := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "gh-token", Namespace: "default"},
+		Data:       map[string][]byte{"GITHUB_TOKEN": []byte("ghp_test_secret")},
+	}
+	r := newReconciler(team, token)
+	r.GitHubBaseURL = srv.URL
+	team = fetch(t, r, "partial-perm")
+
+	require.NoError(t, r.executeCreatePR(context.Background(), team),
+		"PR creation is the primary deliverable — reviewer/label failures must not fail the whole operation")
+	assert.True(t, prCreated)
+	require.NotNil(t, team.Status.PullRequest)
+	assert.Equal(t, "https://github.com/a/b/pull/7", team.Status.PullRequest.URL)
+}
+
+// --- Title templating ---
+
+func TestRenderPRTitle_Default(t *testing.T) {
+	team := minimalTeam("defaulty")
+	title, err := renderPRTitle(team)
+	require.NoError(t, err)
+	assert.Equal(t, "claude-teams: defaulty", title)
+}
+
+func TestRenderPRTitle_LifecycleLevelOverride(t *testing.T) {
+	team := minimalTeam("over")
+	team.Spec.Lifecycle = &claudev1alpha1.LifecycleSpec{
+		PRTitleTemplate: "[bot] {{.TeamName}} in {{.Namespace}}",
+	}
+	title, err := renderPRTitle(team)
+	require.NoError(t, err)
+	assert.Equal(t, "[bot] over in default", title)
+}
+
+func TestRenderPRTitle_FallsBackToPullRequestSpecTemplate(t *testing.T) {
+	team := minimalTeam("fb")
+	team.Spec.Lifecycle = &claudev1alpha1.LifecycleSpec{
+		PullRequest: &claudev1alpha1.PullRequestSpec{TitleTemplate: "pr-spec: {{.TeamName}}"},
+	}
+	title, err := renderPRTitle(team)
+	require.NoError(t, err)
+	assert.Equal(t, "pr-spec: fb", title)
+}
+
+func TestRenderPRTitle_LifecycleTakesPrecedenceOverPullRequestSpec(t *testing.T) {
+	team := minimalTeam("pri")
+	team.Spec.Lifecycle = &claudev1alpha1.LifecycleSpec{
+		PRTitleTemplate: "lifecycle wins",
+		PullRequest:     &claudev1alpha1.PullRequestSpec{TitleTemplate: "pr-spec"},
+	}
+	title, err := renderPRTitle(team)
+	require.NoError(t, err)
+	assert.Equal(t, "lifecycle wins", title)
+}
+
+// --- PR body ---
+
+func TestBuildPRBody_IncludesTeamAndTasks(t *testing.T) {
+	team := minimalTeam("body-test")
+	team.Status.Tasks = &claudev1alpha1.TaskSummary{Total: 10, Completed: 7}
+	team.Status.Teammates = []claudev1alpha1.TeammateStatus{
+		{Name: "reviewer", AgentStatus: claudev1alpha1.AgentStatus{Phase: "Completed"}, TasksCompleted: 3, RestartCount: 1},
+	}
+	team.Status.EstimatedCost = "2.50"
+
+	body := buildPRBody(team)
+	assert.Contains(t, body, "body-test")
+	assert.Contains(t, body, "Completed: 7")
+	assert.Contains(t, body, "Total: 10")
+	assert.Contains(t, body, "reviewer")
+	assert.Contains(t, body, "restarts=1")
+	assert.Contains(t, body, "$2.50")
+}
+
+// --- Branch selection ---
+
+func TestPRBranches_DefaultsToMain(t *testing.T) {
+	team := minimalTeam("branches")
+	head, base := prBranches(team)
+	assert.Equal(t, "main", head, "head falls back to 'main' when no repo branch is set")
+	assert.Equal(t, "main", base)
+}
+
+func TestPRBranches_UsesRepoBranchAndTargetBranch(t *testing.T) {
+	team := minimalTeam("b")
+	team.Spec.Repository = &claudev1alpha1.RepositorySpec{URL: "https://github.com/x/y", Branch: "work"}
+	team.Spec.Lifecycle = &claudev1alpha1.LifecycleSpec{
+		PullRequest: &claudev1alpha1.PullRequestSpec{TargetBranch: "develop"},
+	}
+	head, base := prBranches(team)
+	assert.Equal(t, "work", head)
+	assert.Equal(t, "develop", base)
+}
+

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1,0 +1,168 @@
+// Package github is a minimal GitHub REST API client covering just what the
+// operator needs for OnComplete=create-pr. Kept intentionally narrow — no
+// external SDK, no webhooks, no GraphQL — so the dependency surface stays
+// small and the blast radius of a bad token is easy to reason about.
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// DefaultBaseURL is the public GitHub API root. Overridable via WithBaseURL
+// for GitHub Enterprise and for tests that stand up an httptest server.
+const DefaultBaseURL = "https://api.github.com"
+
+// DefaultTimeout bounds a single HTTP call. Short enough that a flaky API
+// cannot stall the reconciler, long enough that a slow-but-healthy network
+// round-trip still completes.
+const DefaultTimeout = 15 * time.Second
+
+// Client issues authenticated HTTP requests to the GitHub REST API.
+type Client struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+// Option customizes a Client at construction time.
+type Option func(*Client)
+
+// WithBaseURL overrides the API base URL. Used for GitHub Enterprise and
+// httptest servers in tests.
+func WithBaseURL(url string) Option {
+	return func(c *Client) { c.baseURL = strings.TrimSuffix(url, "/") }
+}
+
+// WithHTTPClient injects a custom http.Client (primarily for tests).
+func WithHTTPClient(h *http.Client) Option {
+	return func(c *Client) { c.http = h }
+}
+
+// NewClient returns a Client authenticated with the given token. An empty
+// token is accepted but every request will fail at the API — callers should
+// validate upstream.
+func NewClient(token string, opts ...Option) *Client {
+	c := &Client{
+		baseURL: DefaultBaseURL,
+		token:   token,
+		http:    &http.Client{Timeout: DefaultTimeout},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// PullRequestRequest is the subset of the GitHub "create pull request" body
+// the operator fills in. Optional reviewers/labels are applied via follow-up
+// calls after PR creation.
+type PullRequestRequest struct {
+	Title string `json:"title"`
+	Body  string `json:"body,omitempty"`
+	Head  string `json:"head"`
+	Base  string `json:"base"`
+	Draft bool   `json:"draft,omitempty"`
+}
+
+// PullRequest is the subset of the GitHub pull request payload the operator
+// persists into AgentTeam.status.pullRequest.
+type PullRequest struct {
+	Number  int    `json:"number"`
+	HTMLURL string `json:"html_url"`
+	State   string `json:"state"`
+}
+
+// CreatePullRequest opens a PR against owner/repo and returns the created
+// resource. API errors are surfaced with the GitHub response body so
+// "Validation Failed" messages propagate to kubectl describe.
+func (c *Client) CreatePullRequest(ctx context.Context, owner, repo string, req *PullRequestRequest) (*PullRequest, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal PR request: %w", err)
+	}
+	path := fmt.Sprintf("/repos/%s/%s/pulls", url.PathEscape(owner), url.PathEscape(repo))
+	var pr PullRequest
+	if err := c.do(ctx, http.MethodPost, path, body, &pr); err != nil {
+		return nil, err
+	}
+	return &pr, nil
+}
+
+// RequestReviewers adds reviewer usernames to an existing PR. No-op when
+// the list is empty.
+func (c *Client) RequestReviewers(ctx context.Context, owner, repo string, number int, reviewers []string) error {
+	if len(reviewers) == 0 {
+		return nil
+	}
+	body, err := json.Marshal(map[string][]string{"reviewers": reviewers})
+	if err != nil {
+		return err
+	}
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d/requested_reviewers",
+		url.PathEscape(owner), url.PathEscape(repo), number)
+	return c.do(ctx, http.MethodPost, path, body, nil)
+}
+
+// AddLabels applies issue labels to the PR (PRs are issues under GitHub's
+// data model). No-op when the list is empty.
+func (c *Client) AddLabels(ctx context.Context, owner, repo string, number int, labels []string) error {
+	if len(labels) == 0 {
+		return nil
+	}
+	body, err := json.Marshal(map[string][]string{"labels": labels})
+	if err != nil {
+		return err
+	}
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/labels",
+		url.PathEscape(owner), url.PathEscape(repo), number)
+	return c.do(ctx, http.MethodPost, path, body, nil)
+}
+
+// do performs an authenticated request and, when result is non-nil, decodes
+// the JSON response into it. Non-2xx responses are returned as errors with
+// the response body attached so upstream callers can record the failure on
+// the AgentTeam status.
+func (c *Client) do(ctx context.Context, method, path string, body []byte, result interface{}) error {
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("GitHub API %s %s returned %d: %s",
+			method, path, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	if result != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, result); err != nil {
+			return fmt.Errorf("decode GitHub response: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,0 +1,191 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRepo_HTTPS(t *testing.T) {
+	cases := []struct {
+		url, owner, repo string
+	}{
+		{"https://github.com/amcheste/claude-teams-operator", "amcheste", "claude-teams-operator"},
+		{"https://github.com/amcheste/claude-teams-operator.git", "amcheste", "claude-teams-operator"},
+		{"https://github.com/amcheste/claude-teams-operator/", "amcheste", "claude-teams-operator"},
+		{"http://ghe.internal/team/project.git", "team", "project"},
+	}
+	for _, c := range cases {
+		owner, repo, err := ParseRepo(c.url)
+		require.NoError(t, err, "url=%s", c.url)
+		assert.Equal(t, c.owner, owner, "url=%s", c.url)
+		assert.Equal(t, c.repo, repo, "url=%s", c.url)
+	}
+}
+
+func TestParseRepo_SSH(t *testing.T) {
+	cases := []struct {
+		url, owner, repo string
+	}{
+		{"git@github.com:amcheste/claude-teams-operator.git", "amcheste", "claude-teams-operator"},
+		{"git@github.com:amcheste/claude-teams-operator", "amcheste", "claude-teams-operator"},
+	}
+	for _, c := range cases {
+		owner, repo, err := ParseRepo(c.url)
+		require.NoError(t, err, "url=%s", c.url)
+		assert.Equal(t, c.owner, owner, "url=%s", c.url)
+		assert.Equal(t, c.repo, repo, "url=%s", c.url)
+	}
+}
+
+func TestParseRepo_Invalid(t *testing.T) {
+	for _, bad := range []string{"", "not a url", "github.com/only-owner"} {
+		_, _, err := ParseRepo(bad)
+		assert.Error(t, err, "url=%s", bad)
+	}
+}
+
+func TestCreatePullRequest_HappyPath(t *testing.T) {
+	var received struct {
+		auth    string
+		method  string
+		path    string
+		apiVers string
+		accept  string
+		body    PullRequestRequest
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received.auth = r.Header.Get("Authorization")
+		received.method = r.Method
+		received.path = r.URL.Path
+		received.apiVers = r.Header.Get("X-GitHub-Api-Version")
+		received.accept = r.Header.Get("Accept")
+		_ = json.NewDecoder(r.Body).Decode(&received.body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"number": 42, "html_url": "https://github.com/acme/repo/pull/42", "state": "open"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient("ghp_test_token", WithBaseURL(srv.URL))
+	pr, err := c.CreatePullRequest(context.Background(), "acme", "repo", &PullRequestRequest{
+		Title: "Team finished",
+		Body:  "Task list complete",
+		Head:  "claude-teams/auth-refactor",
+		Base:  "main",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 42, pr.Number)
+	assert.Equal(t, "https://github.com/acme/repo/pull/42", pr.HTMLURL)
+	assert.Equal(t, "open", pr.State)
+
+	assert.Equal(t, "POST", received.method)
+	assert.Equal(t, "/repos/acme/repo/pulls", received.path)
+	assert.Equal(t, "Bearer ghp_test_token", received.auth)
+	assert.Equal(t, "2022-11-28", received.apiVers)
+	assert.Contains(t, received.accept, "vnd.github+json")
+	assert.Equal(t, "Team finished", received.body.Title)
+	assert.Equal(t, "claude-teams/auth-refactor", received.body.Head)
+	assert.Equal(t, "main", received.body.Base)
+}
+
+func TestCreatePullRequest_APIErrorIncludesBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"message":"Validation Failed","errors":[{"field":"head","code":"invalid"}]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient("t", WithBaseURL(srv.URL))
+	_, err := c.CreatePullRequest(context.Background(), "a", "b", &PullRequestRequest{
+		Title: "x", Head: "h", Base: "main",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "422")
+	assert.Contains(t, err.Error(), "Validation Failed", "error must surface GitHub's message for kubectl describe")
+}
+
+func TestRequestReviewers_NoOpOnEmptyList(t *testing.T) {
+	// An empty reviewer list must not issue a request — otherwise teams
+	// without reviewers would trip permission errors on repos that don't
+	// have any collaborators.
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+
+	c := NewClient("t", WithBaseURL(srv.URL))
+	require.NoError(t, c.RequestReviewers(context.Background(), "a", "b", 1, nil))
+	require.NoError(t, c.RequestReviewers(context.Background(), "a", "b", 1, []string{}))
+	assert.False(t, called)
+}
+
+func TestRequestReviewers_PostsNames(t *testing.T) {
+	var body string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		body = string(b)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := NewClient("t", WithBaseURL(srv.URL))
+	require.NoError(t, c.RequestReviewers(context.Background(), "a", "b", 7, []string{"alice", "bob"}))
+	assert.Contains(t, body, "alice")
+	assert.Contains(t, body, "bob")
+}
+
+func TestAddLabels_NoOpOnEmptyList(t *testing.T) {
+	var called bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+
+	c := NewClient("t", WithBaseURL(srv.URL))
+	require.NoError(t, c.AddLabels(context.Background(), "a", "b", 1, nil))
+	assert.False(t, called)
+}
+
+func TestAddLabels_PostsToIssuesEndpoint(t *testing.T) {
+	// GitHub treats PR labels as issue labels — the request must hit
+	// /issues/N/labels, not /pulls/N/labels (which doesn't exist).
+	var path string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient("t", WithBaseURL(srv.URL))
+	require.NoError(t, c.AddLabels(context.Background(), "a", "b", 7, []string{"claude"}))
+	assert.True(t, strings.Contains(path, "/issues/7/labels"),
+		"labels must go to /issues/N/labels — got %q", path)
+}
+
+func TestClient_EmptyTokenOmitsAuthHeader(t *testing.T) {
+	// Empty token should not produce an `Authorization: Bearer ` header — the
+	// upstream caller is expected to validate token presence first, but the
+	// client should not send an obviously malformed request.
+	var auth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"number": 1}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient("", WithBaseURL(srv.URL))
+	_, err := c.CreatePullRequest(context.Background(), "a", "b", &PullRequestRequest{Title: "x", Head: "h", Base: "main"})
+	require.NoError(t, err)
+	assert.Empty(t, auth)
+}

--- a/internal/github/parse.go
+++ b/internal/github/parse.go
@@ -1,0 +1,31 @@
+package github
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// httpsRepo matches https://github.com/owner/repo(.git)? and
+// https://<host>/owner/repo(.git)?
+var httpsRepo = regexp.MustCompile(`^https?://[^/]+/([^/]+)/([^/]+?)(?:\.git)?/?$`)
+
+// sshRepo matches git@github.com:owner/repo(.git)?
+var sshRepo = regexp.MustCompile(`^[^@]+@[^:]+:([^/]+)/([^/]+?)(?:\.git)?/?$`)
+
+// ParseRepo extracts the owner and repository name from a git clone URL.
+// Recognizes both HTTPS (https://github.com/owner/repo.git) and SSH
+// (git@github.com:owner/repo.git) forms and tolerates a trailing slash or
+// missing .git suffix.
+func ParseRepo(url string) (owner, repo string, err error) {
+	url = strings.TrimSpace(url)
+	if url == "" {
+		return "", "", fmt.Errorf("empty repository URL")
+	}
+	for _, re := range []*regexp.Regexp{httpsRepo, sshRepo} {
+		if m := re.FindStringSubmatch(url); m != nil {
+			return m[1], m[2], nil
+		}
+	}
+	return "", "", fmt.Errorf("unrecognized git URL format: %q", url)
+}


### PR DESCRIPTION
Closes #15.

## Summary
- The `create-pr` OnComplete action now opens a real GitHub pull request when a coding team finishes instead of the log-only stub. Closes the coding-team loop end-to-end: **team finishes → PR appears on GitHub**.
- New `internal/github` package wraps the minimum REST endpoints the operator needs (no SDK — stdlib `net/http`).
- Two CRD additions to `LifecycleSpec`: `GitHubTokenSecret` (Secret with `GITHUB_TOKEN`) and `PRTitleTemplate` (Go template).

## CRD additions

```yaml
spec:
  lifecycle:
    onComplete: create-pr
    githubTokenSecret: gh-pat        # NEW — Secret with GITHUB_TOKEN key
    prTitleTemplate: "claude: {{.TeamName}}"  # NEW, optional — overrides pullRequest.titleTemplate
    pullRequest:
      targetBranch: main
      reviewers: [alice]
      labels: [ai, automated]
```

Title precedence: `lifecycle.prTitleTemplate` > `lifecycle.pullRequest.titleTemplate` > default `"claude-teams: {{.TeamName}}"`.

## Error-surfacing design
- Configuration errors (missing repo URL, missing token Secret, Secret without `GITHUB_TOKEN` key) → returned from `executeCreatePR`. The `reconcileRunning` caller already swallows errors so the team still reaches `Completed`, but `executeOnComplete` emits a `PRCreationFailed` Warning event carrying GitHub's body text — visible in `kubectl describe agentteam`.
- Non-2xx API responses bubble up the GitHub error body (e.g. "422 Validation Failed: head is invalid") so operators aren't left guessing why the PR didn't open.
- Reviewer/label failures are **logged, not returned** — the PR is the primary deliverable, and a token with `pull-write` but no `issue-write` scopes should still succeed.

## Test plan
- [x] `go test ./internal/github/...` — 10 tests: HTTPS/SSH URL parsing, `.git` suffix tolerance, happy path with auth header + API version, 422 body surfaced in error, reviewer/label endpoints + no-op on empty list, empty-token omits Authorization header
- [x] `go test ./internal/controller/...` — 13 new `CreatePR` tests: happy path end-to-end against httptest GitHub, missing repo URL, missing token Secret, Secret without `GITHUB_TOKEN` key, 422 error surfacing, reviewer/label failures don't block PR creation, title templating precedence, body contains tasks/teammates/cost, branch defaults and overrides
- [x] Full `go test ./...`, `go vet`, `helm lint`, `make manifests generate && git diff --exit-code` — all green

## KubeCon stage moment

Kill a team spec with `onComplete: create-pr`, wait 30 seconds, `kubectl get agentteam -o wide` shows `status.pullRequest.url` pointing at a freshly-opened PR. The audience clicks through and sees real code, real reviewers, real labels. This is the v0.4.0 headline.

## Status after this

v0.4.0: **3/4** done (#13 crash respawn, #14 per-agent RBAC, #15 create-pr). Last in the milestone: [#16 push-branch](https://github.com/amcheste/claude-teams-operator/issues/16) — consolidating worktree branches into one head branch before create-pr. Pairs naturally with the work here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)