### PR TITLE
ci(release): gate artifact publish on acceptance + real-API E2E

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,11 +1,13 @@
 name: Acceptance Tests
 
-# Runs on PRs from develop → main (the release gate) and on demand.
-# Purpose: spin up a real Kind cluster, deploy the operator, and exercise the
-# full AgentTeam lifecycle before any code lands on main.
+# Runs on PRs from develop → main (the release gate), on tag releases (called
+# from release.yml), and on demand. Purpose: spin up a real Kind cluster,
+# deploy the operator, and exercise the full AgentTeam lifecycle before any
+# code lands on main — or any tagged artifact ships to users.
 on:
   pull_request:
     branches: [main]
+  workflow_call:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,7 @@ name: E2E Tests (Real Claude API)
 # Real-API E2E runs hit the Anthropic API and cost money per run. We gate them
 # tightly:
 #   * Only on pushes to main (post-merge, final verification before a release)
+#   * Called from release.yml before any artifact ships (fail_if_no_key=true)
 #   * Only when the ANTHROPIC_API_KEY secret is configured
 #   * workflow_dispatch available for ad-hoc manual runs by maintainers
 #
@@ -11,6 +12,12 @@ name: E2E Tests (Real Claude API)
 on:
   push:
     branches: [main]
+  workflow_call:
+    inputs:
+      fail_if_no_key:
+        description: 'Fail when ANTHROPIC_API_KEY is unset instead of skipping silently. Set true when calling from the release pipeline.'
+        type: boolean
+        default: false
   workflow_dispatch:
 
 permissions:
@@ -29,10 +36,19 @@ jobs:
       - id: check
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          FAIL_IF_NO_KEY: ${{ inputs.fail_if_no_key }}
         run: |
           if [ -n "$ANTHROPIC_API_KEY" ]; then
             echo "has_key=true" >> "$GITHUB_OUTPUT"
             echo "ANTHROPIC_API_KEY is configured — E2E job will run."
+          elif [ "$FAIL_IF_NO_KEY" = "true" ]; then
+            # Release path: skipping E2E silently would publish artifacts that
+            # haven't been verified against the real Anthropic API. Fail loud
+            # so the maintainer sees it and configures the secret.
+            echo "::error::ANTHROPIC_API_KEY secret is not configured on this repo."
+            echo "::error::A release cannot ship without real-API E2E validation."
+            echo "::error::Configure the secret with: gh secret set ANTHROPIC_API_KEY --repo amcheste/claude-teams-operator"
+            exit 1
           else
             echo "has_key=false" >> "$GITHUB_OUTPUT"
             echo "::warning::ANTHROPIC_API_KEY not configured — E2E job will be skipped."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,30 @@ jobs:
     name: Validate Before Release
     uses: ./.github/workflows/validate.yml
 
+  # ── Gate: Kind-based acceptance tests on the tag commit ───────────────────
+  # Exercises the operator's reconcile loop, PVC provisioning, and pod
+  # lifecycle on a real cluster. Duplicate of the PR-time run, but on the
+  # exact commit being released. Cheap insurance.
+  acceptance:
+    name: Acceptance Before Release
+    uses: ./.github/workflows/acceptance.yml
+
+  # ── Gate: real-API E2E on the tag commit ──────────────────────────────────
+  # fail_if_no_key=true promotes "ANTHROPIC_API_KEY not configured" from a
+  # silent skip into a hard failure. Without this, a release could publish
+  # artifacts that never exercised the real Claude path.
+  e2e:
+    name: E2E Before Release
+    uses: ./.github/workflows/e2e.yml
+    with:
+      fail_if_no_key: true
+    secrets: inherit
+
   # ── Build and push container images ───────────────────────────────────────
   images:
     name: Build & Push Images
     runs-on: ubuntu-latest
-    needs: validate
+    needs: [validate, acceptance, e2e]
     permissions:
       contents: read
       packages: write
@@ -103,7 +122,7 @@ jobs:
   chart:
     name: Publish Helm Chart
     runs-on: ubuntu-latest
-    needs: validate
+    needs: [validate, acceptance, e2e]
     permissions:
       contents: read
       packages: write
@@ -145,7 +164,7 @@ jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [validate, images, chart]
+    needs: [validate, acceptance, e2e, images, chart]
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Problem
Today `release.yml` only runs `validate.yml` (unit tests + lint) before publishing images, the Helm chart, and the GitHub Release. The acceptance + E2E suites exist but run on separate triggers:
- `acceptance.yml` runs on `pull_request` into `main`
- `e2e.yml` runs on `push` to `main` but **skips silently when `ANTHROPIC_API_KEY` is not configured**

Empirically — every post-merge E2E run on main since v0.1.0 has completed in **5-6 seconds** (the skip path). The secret was never set, so **v0.1.0, v0.2.0, and v0.3.0 were all published without real-API validation**.

## Fix
Promote `acceptance.yml` and `e2e.yml` to reusable workflows and require both in `release.yml` alongside `validate`. Every tag push now runs:

| Gate | Exercises |
|---|---|
| validate | go vet, go test, helm lint, manifest drift |
| acceptance | Kind cluster + reconcile loop (busybox agents) |
| e2e | Kind cluster + real Claude Code runner + real Anthropic API |

Only if **all three** succeed do `images`, `chart`, and `release` proceed.

## Key behavior change

`e2e.yml` gets a new `workflow_call` input `fail_if_no_key` (default `false`). When `release.yml` calls it with `fail_if_no_key: true`:

- `ANTHROPIC_API_KEY` unset → **hard preflight failure** with a pointer to `gh secret set`
- `ANTHROPIC_API_KEY` set → real E2E runs

The existing `push: [main]` trigger keeps the soft-skip behavior so forks and un-configured clones don't fail on day-to-day main pushes.

## Consequence for v0.4.0

Before we cut v0.4.0, **`ANTHROPIC_API_KEY` must be set as a repo secret**:

```bash
gh secret set ANTHROPIC_API_KEY --repo amcheste/claude-teams-operator
```

If it's not set when the release tag is pushed, the pipeline fails at the E2E preflight with a red message pointing at that command.

## Test plan
- [x] YAML syntax validated for all three modified workflows
- [x] `release.yml` job graph: `validate + acceptance + e2e → images + chart → release`
- [ ] Post-merge to develop: `acceptance.yml` still runs on a next develop→main PR (should be a no-op since the workflow_call addition is purely additive)
- [ ] After merging, set `ANTHROPIC_API_KEY` secret and observe that the first tag push exercises all three gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)